### PR TITLE
.gitignore file also needs to ignore itself

### DIFF
--- a/Clockwork/Storage/FileStorage.php
+++ b/Clockwork/Storage/FileStorage.php
@@ -25,8 +25,8 @@ class FileStorage extends Storage
 			if (!mkdir($path, 0700, true))
 				throw new Exception('Directory "' . $path . '" does not exist.');
 
-			# create default .gitignore, to ignore stored json files
-			file_put_contents($path . '/.gitignore', "*.json\n");
+			# create default .gitignore, to ignore all files in clockwork storage folder
+			file_put_contents($path . '/.gitignore', "*\n");
 		}
 
 		if (!is_writable($path)) 


### PR DESCRIPTION
The .gitignore file in the app/storage/clockwork folder doesn't just need to ignore .json files, it also needs to ignore itself, otherwise the .gitignore file appears in untracked changes.

Cheers,

Dan
