### PR TITLE
Added custom header support to Laravel.

### DIFF
--- a/Clockwork/Support/Laravel/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Laravel/ClockworkServiceProvider.php
@@ -88,6 +88,13 @@ class ClockworkServiceProvider extends ServiceProvider
 				if ($app['request']->getBasePath()) {
 					$response->headers->set('X-Clockwork-Path', $app['request']->getBasePath() . '/__clockwork/', true);
 				}
+				
+				$extraHeaders = $this->app['config']->get('clockwork::headers');
+				if ($extraHeaders and is_array($extraHeaders)) {
+					foreach ($extraHeaders as $headerName => $headerValue) {
+						$response->headers->set('X-Clockwork-Header-'.$headerName, $headerValue);
+					}
+				}
 			}
 		});
 

--- a/Clockwork/Support/Laravel/config/config.php
+++ b/Clockwork/Support/Laravel/config/config.php
@@ -57,6 +57,22 @@ return array(
 
     'filter_uris' => array(
         '/__clockwork/.*', // disable collecting data for clockwork-web assets
-    )
+    ),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Send Headers for AJAX request
+    |--------------------------------------------------------------------------
+    |
+    | When trying to collect data the AJAX method can sometimes fail if it is 
+    | missing required headers. For example, an API might require a version 
+    | number using Accept headers to route the HTTP request to the correct 
+    | codebase.
+    |
+    */
+
+    'headers' => array(
+        // 'Accept' => 'application/vnd.com.whatever.v1+json',
+    ),
 
 );


### PR DESCRIPTION
Implemented custom header support added in https://github.com/itsgoingd/clockwork-chrome/pull/11 for Laravel 4, and updated the config file to match.
