### PR TITLE
Disable data collection by default

### DIFF
--- a/Clockwork/Support/Laravel/config/config.php
+++ b/Clockwork/Support/Laravel/config/config.php
@@ -25,11 +25,11 @@ return array(
     |
     | This setting controls, whether data about application requests will be
     | recorded even when Clockwork is disabled (useful for later analysis).
-    | Default: true
+    | Default: false
     |
     */
 
-    'collect_data_always' => true,
+    'collect_data_always' => false,
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
I don't think this is an option that should be enabled by default. I did not know this option existed, and on production, the clockwork storage folder was full of these data files.

I think default behavior should be to follow app.debug, and if the user wants data collection, he should set the value to true.
