### PR TITLE
Laravel service provider: catch "finish" instead of "after"

### DIFF
--- a/Clockwork/Support/Laravel/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Laravel/ClockworkServiceProvider.php
@@ -75,7 +75,7 @@ class ClockworkServiceProvider extends ServiceProvider
 
 		$app = $this->app;
 		$service = $this;
-		$this->app->after(function($request, $response) use($app, $service)
+		$this->app->finish(function($request, $response) use($app, $service)
 		{
 			if (!$service->isCollectingData()) {
 				return; // Collecting data is disabled, return immediately


### PR DESCRIPTION
That allows clockwork log all queries, including 404 and other errors.
