### PR TITLE
CodeIgniter Fix - Hook::setStoragePath not static

### DIFF
--- a/Clockwork/Support/CodeIgniter/Hook.php
+++ b/Clockwork/Support/CodeIgniter/Hook.php
@@ -23,7 +23,7 @@ class Hook
 		self::$__disabled = true;
 	}
 	
-	public function setStoragePath($storagePath = null)
+	public static function setStoragePath($storagePath = null)
 	{
 		if ($storagePath == null) {
 			return;


### PR DESCRIPTION
[Register.php refers to setStoragePath statically](https://github.com/itsgoingd/clockwork/blob/master/Clockwork/Support/CodeIgniter/Register.php#L28), but the method was not declared static.
