### PR TITLE
PHP 5.3 compatibility for abstract methods

### DIFF
--- a/Clockwork/Storage/Storage.php
+++ b/Clockwork/Storage/Storage.php
@@ -15,12 +15,6 @@ abstract class Storage implements StorageInterface
 	public $filter = array();
 
 	/**
-	 * Retrieve request specified by id argument, if second argument is specified, array of requests from id to last
-	 * will be returned
-	 */
-	abstract public function retrieve($id = null, $last = null);
-
-	/**
 	 * Same as retrieve, but json representations of requests are returned
 	 */
 	public function retrieveAsJson($id = null, $last = null)
@@ -38,11 +32,6 @@ abstract class Storage implements StorageInterface
 
 		return json_encode($requests);
 	}
-
-	/**
-	 * Store request
-	 */
-	abstract public function store(Request $request);
 
 	/**
 	 * Return array of data with applied filter


### PR DESCRIPTION
We need to remove the "middleware abstract definitions" for php 5.3 compatibility otherwise we get hit with `Can't inherit abstract function Clockwork\\Storage\\StorageInterface::store() (previously declared abstract in Clockwork\\Storage\\Storage` - see http://stackoverflow.com/questions/17525620/php-fatal-error-cant-inherit-abstract-function#answer-22521203 for more information.
