### PR TITLE
make whitespace consistent in file

### DIFF
--- a/Clockwork/Clockwork.php
+++ b/Clockwork/Clockwork.php
@@ -185,45 +185,45 @@ class Clockwork implements LoggerInterface
 		return $this->getLog()->log($level, $message, $context);
 	}
 
-    public function emergency($message, array $context = array())
-    {
-        return $this->getLog()->log(LogLevel::EMERGENCY, $message, $context);
-    }
+	public function emergency($message, array $context = array())
+	{
+		return $this->getLog()->log(LogLevel::EMERGENCY, $message, $context);
+	}
 
-    public function alert($message, array $context = array())
-    {
-        return $this->getLog()->log(LogLevel::ALERT, $message, $context);
-    }
+	public function alert($message, array $context = array())
+	{
+		return $this->getLog()->log(LogLevel::ALERT, $message, $context);
+	}
 
-    public function critical($message, array $context = array())
-    {
-        return $this->getLog()->log(LogLevel::CRITICAL, $message, $context);
-    }
+	public function critical($message, array $context = array())
+	{
+		return $this->getLog()->log(LogLevel::CRITICAL, $message, $context);
+	}
 
-    public function error($message, array $context = array())
-    {
-        return $this->getLog()->log(LogLevel::ERROR, $message, $context);
-    }
+	public function error($message, array $context = array())
+	{
+		return $this->getLog()->log(LogLevel::ERROR, $message, $context);
+	}
 
-    public function warning($message, array $context = array())
-    {
-        return $this->getLog()->log(LogLevel::WARNING, $message, $context);
-    }
+	public function warning($message, array $context = array())
+	{
+		return $this->getLog()->log(LogLevel::WARNING, $message, $context);
+	}
 
-    public function notice($message, array $context = array())
-    {
-        return $this->getLog()->log(LogLevel::NOTICE, $message, $context);
-    }
+	public function notice($message, array $context = array())
+	{
+		return $this->getLog()->log(LogLevel::NOTICE, $message, $context);
+	}
 
-    public function info($message, array $context = array())
-    {
-        return $this->getLog()->log(LogLevel::INFO, $message, $context);
-    }
+	public function info($message, array $context = array())
+	{
+		return $this->getLog()->log(LogLevel::INFO, $message, $context);
+	}
 
-    public function debug($message, array $context = array())
-    {
-        return $this->getLog()->log(LogLevel::DEBUG, $message, $context);
-    }
+	public function debug($message, array $context = array())
+	{
+		return $this->getLog()->log(LogLevel::DEBUG, $message, $context);
+	}
 
 	/**
 	 * Shortcut methods for the current timeline instance


### PR DESCRIPTION
The log level logging methods were indented with spaces, whereas the majority of the file was indented with tabs. Fixed.