### PR TITLE
Use controllers to handle routing logic.

### DIFF
--- a/Clockwork/Support/Laravel/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Laravel/ClockworkServiceProvider.php
@@ -27,11 +27,11 @@ class ClockworkServiceProvider extends ServiceProvider
 			return; // Clockwork is disabled, don't register the route
 		}
 
-		$app = $this->app;
-		$this->app['router']->get('/__clockwork/{id}', function($id = null, $last = null) use($app)
-		{
-			return $app['clockwork.support']->getData($id, $last);
-		})->where('id', '[0-9\.]+');
+		if ($this->isLegacyLaravel() || $this->isOldLaravel()) {
+			$this->app['router']->get('/__clockwork/{id}', 'Clockwork\Support\Laravel\LegacyController@getData')->where('id', '[0-9\.]+');
+		} else {
+			$this->app['router']->get('/__clockwork/{id}', 'Clockwork\Support\Laravel\ClockworkController@getData')->where('id', '[0-9\.]+');
+		}
 	}
 
 	public function register()

--- a/Clockwork/Support/Laravel/Controllers/CurrentController.php
+++ b/Clockwork/Support/Laravel/Controllers/CurrentController.php
@@ -1,0 +1,17 @@
+<?php namespace Clockwork\Support\Laravel\Controllers;
+
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Routing\Controller;
+
+class CurrentController extends Controller {
+
+	public $app;
+
+	public function __construct(Application $app) {
+		$this->app = $app;
+	}
+
+	public function getData($id = null, $last = null) {
+		return $this->app['clockwork.support']->getData($id, $last);
+	}
+}

--- a/Clockwork/Support/Laravel/Controllers/LegacyController.php
+++ b/Clockwork/Support/Laravel/Controllers/LegacyController.php
@@ -1,0 +1,17 @@
+<?php namespace Clockwork\Support\Laravel\Controllers;
+
+use Illuminate\Foundation\Application;
+use Illuminate\Routing\Controllers\Controller;
+
+class LegacyController extends Controller {
+
+	public $app;
+
+	public function __construct(Application $app) {
+		$this->app = $app;
+	}
+
+	public function getData($id = null, $last = null) {
+		return $this->app['clockwork.support']->getData($id, $last);
+	}
+}


### PR DESCRIPTION
This sets up clockwork to use a controller class for the logic to grab data instead of a closure. This change allows for Laravel 5 applications in development to be able to cache routes to verify their routes will fully cache in production. I created a legacy controller as well instead of using a closure for old laravel installs for consistency, but old installs it doesn't matter at all.