### PR TITLE
Fix incorrect FQCNs in ClockworkServiceProvider

### DIFF
--- a/Clockwork/Support/Laravel/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Laravel/ClockworkServiceProvider.php
@@ -28,9 +28,9 @@ class ClockworkServiceProvider extends ServiceProvider
 		}
 
 		if ($this->isLegacyLaravel() || $this->isOldLaravel()) {
-			$this->app['router']->get('/__clockwork/{id}', 'Clockwork\Support\Laravel\LegacyController@getData')->where('id', '[0-9\.]+');
+			$this->app['router']->get('/__clockwork/{id}', 'Clockwork\Support\Laravel\Controllers\LegacyController@getData')->where('id', '[0-9\.]+');
 		} else {
-			$this->app['router']->get('/__clockwork/{id}', 'Clockwork\Support\Laravel\ClockworkController@getData')->where('id', '[0-9\.]+');
+			$this->app['router']->get('/__clockwork/{id}', 'Clockwork\Support\Laravel\Controllers\CurrentController@getData')->where('id', '[0-9\.]+');
 		}
 	}
 


### PR DESCRIPTION
After doing a `composer update` this morning Clockwork was broken for me. Tracked it down to PR #90. Look at the paths provided in `ClockworkServiceProvider `:

* `Clockwork\Support\Laravel\LegacyController`
* `Clockwork\Support\Laravel\ClockworkController`

The controllers are namespaced to `Clockwork\Support\Laravel\Controllers` and the `ClockworkController` class doesn't even exist :stuck_out_tongue: