### PR TITLE
Fix fatal usage error for Laravel 4.2 ! Without this the plugin doesn't work anymore...

### DIFF
--- a/Clockwork/Support/Laravel/Controllers/LegacyController.php
+++ b/Clockwork/Support/Laravel/Controllers/LegacyController.php
@@ -1,7 +1,7 @@
 <?php namespace Clockwork\Support\Laravel\Controllers;
 
 use Illuminate\Foundation\Application;
-use Illuminate\Routing\Controllers\Controller;
+use Illuminate\Routing\Controller;
 
 class LegacyController extends Controller {
 


### PR DESCRIPTION
In Laravel 4.2 it's now Illuminate\Routing\Controller instead of Illuminate\Routing\Controllers\Controller;