### PR TITLE
Do not create ClockWorkCleanCommand on every request

### DIFF
--- a/Clockwork/Support/Laravel/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Laravel/ClockworkServiceProvider.php
@@ -109,9 +109,7 @@ class ClockworkServiceProvider extends ServiceProvider
 	public function registerCommands()
 	{
 		// Clean command
-		$this->app['command.clockwork.clean'] = $this->app->share(function($app){
-			return new ClockworkCleanCommand();
-		});
+		$this->app->bind('command.clockwork.clean', 'Clockwork\Support\Laravel\ClockworkCleanCommand');
 
 		$this->commands(
 			'command.clockwork.clean'


### PR DESCRIPTION
As it stands a ClockWorkCleanCommand is created on every request. This results in a exception when testing projects that use this package. When creating the ClockworkCleanCommand the IoC container can't instantiate it.

This PR makes sure the command only gets created when it will be actually used.

Nothing but benefits so I kindly request you merge this in and tag a new version. Thanks!

