### PR TITLE
Fix for Version 4.2-dev

### DIFF
--- a/Clockwork/Support/Laravel/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Laravel/ClockworkServiceProvider.php
@@ -137,11 +137,11 @@ class ClockworkServiceProvider extends ServiceProvider
 
 	public function isLegacyLaravel()
 	{
-		return Str::startsWith(Application::VERSION, array('4.1.', '4.2.'));
+		return Str::startsWith(Application::VERSION, array('4.1', '4.2'));
 	}
 
 	public function isOldLaravel()
 	{
-		return Str::startsWith(Application::VERSION, '4.0.');
+		return Str::startsWith(Application::VERSION, '4.0');
 	}
 }


### PR DESCRIPTION
When I have a project with Laravel 4.2-dev ,

I'm having the error: "Clockwork\Support\Laravel\ClockworkServiceProvider::publishes()"

The problem is that this package didn't recognize my version because of the last dot.
Demian

Sorry for my bad english. I am working on it! :)

![knipsel](https://cloud.githubusercontent.com/assets/5346497/13434094/f8982134-dfd4-11e5-86b5-3a25bee4ce86.JPG)
