### PR TITLE
Add support for Illuminate Database

### DIFF
--- a/Clockwork/DataSource/EloquentDataSource.php
+++ b/Clockwork/DataSource/EloquentDataSource.php
@@ -66,7 +66,7 @@ class EloquentDataSource extends DataSource
 	 */
 	public function registerQuery($event)
 	{
-		$caller = StackTrace::get()->firstNonVendor([ 'itsgoingd', 'laravel' ]);
+		$caller = StackTrace::get()->firstNonVendor([ 'itsgoingd', 'laravel', 'illuminate' ]);
 
 		$this->queries[] = array(
 			'query'      => $event->sql,


### PR DESCRIPTION
The [Illuminate Database](https://github.com/illuminate/database) is a subtree split of the Illuminate Database component, which can be used separately than laravel.
Instead of using namespace laravel, it uses illuminate as the namespace.

So by adding illuminate to vender list, enable clockwork to show the correct caller.