### PR TITLE
Update ServiceProvider for Lumen 5.4

### DIFF
--- a/Clockwork/Support/Lumen/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Lumen/ClockworkServiceProvider.php
@@ -109,7 +109,7 @@ class ClockworkServiceProvider extends ServiceProvider
 	public function registerCommands()
 	{
 		// Clean command
-		$this->app['command.clockwork.clean'] = $this->app->share(function($app){
+		$this->app->singleton('command.clockwork.clean', function($app){
 			return new ClockworkCleanCommand();
 		});
 


### PR DESCRIPTION
This should fix error - Call to undefined method Laravel\Lumen\Application::share() in Lumen 5.4