### PR TITLE
Fix doctrine query parameters array to string conversion

### DIFF
--- a/Clockwork/DataSource/DoctrineDataSource.php
+++ b/Clockwork/DataSource/DoctrineDataSource.php
@@ -99,6 +99,10 @@ class DoctrineDataSource extends DataSource implements SQLLogger
 			}
 		}
 
+                if (is_array($param)) {
+                    $param = implode(",", $param);
+                }
+
 		return $param;
 	}
 


### PR DESCRIPTION
When using ranges as query parameters in the doctrine query builder, you will get a 'Array to string conversion' error. This is caused by
`preg_replace($pattern, "\"$param\"", $sql, 1);`
found on line 81 in Clockwork\DataSource\DoctrineDataSource

This can be reproduced by the following code:

```
$someRange = array(1, 5, 6, 29, 200);
$queryBuilder = $this->createQueryBuilder('gd')
            ->where('gd.range IN (:someRange)')
            ->setParameter('someRange', $someRange);
$query = $queryBuilder->getQuery();
return $query->getResult();
```
