### PR TITLE
Added support for cache stats

### DIFF
--- a/Clockwork/DataSource/DataSource.php
+++ b/Clockwork/DataSource/DataSource.php
@@ -44,4 +44,24 @@ class DataSource implements DataSourceInterface
 
 		return $data;
 	}
+
+	/**
+	 * Attempts to serialize a variable of unspecified type
+	 */
+	protected function serialize($message)
+	{
+		if (is_object($message)) {
+			if (method_exists($message, '__toString')) {
+				return (string) $message;
+			} elseif (method_exists($message, 'toArray')) {
+				return json_encode($message->toArray());
+			} else {
+				return json_encode((array) $message);
+			}
+		} elseif (is_array($message)) {
+			return json_encode($message);
+		}
+
+		return $message;
+	}
 }

--- a/Clockwork/DataSource/LaravelCacheDataSource.php
+++ b/Clockwork/DataSource/LaravelCacheDataSource.php
@@ -1,0 +1,156 @@
+<?php namespace Clockwork\DataSource;
+
+use Clockwork\Helpers\StackTrace;
+use Clockwork\Request\Request;
+
+use Illuminate\Events\Dispatcher as EventDispatcher;
+
+/**
+ * Data source for Laravel cache component, provides cache queries and stats
+ */
+class LaravelCacheDataSource extends DataSource
+{
+	/**
+	 * Event dispatcher
+	 */
+	protected $eventDispatcher;
+
+	/**
+	 * Executed cache queries
+	 */
+	protected $queries = [];
+
+	/**
+	 * Create a new data source instance, takes an event dispatcher as argument
+	 */
+	public function __construct(EventDispatcher $eventDispatcher)
+	{
+		$this->eventDispatcher = $eventDispatcher;
+	}
+
+	/**
+	 * Start listening to cache events
+	 */
+	public function listenToEvents()
+	{
+		$that = $this;
+
+		if (! class_exists('Illuminate\Cache\Events\CacheHit')) {
+			// legacy Laravel 5.1 style events
+			$this->eventDispatcher->listen('cache.hit', function ($key, $value) use ($that) {
+				$this->registerQuery([ 'type' => 'hit', 'key' => $key, 'value' => $value ]);
+			});
+			$this->eventDispatcher->listen('cache.missed', function ($key) use ($that) {
+				$this->registerQuery([ 'type' => 'miss', 'key' => $key ]);
+			});
+			$this->eventDispatcher->listen('cache.write', function ($key, $value, $minutes) use ($that) {
+				$this->registerQuery([
+					'type' => 'write', 'key' => $key, 'value' => $value, 'expiration' => $minutes * 60
+				]);
+			});
+			$this->eventDispatcher->listen('cache.delete', function ($key) use ($that) {
+				$this->registerQuery([ 'type' => 'delete', 'key' => $key ]);
+			});
+
+			return;
+		}
+
+		$this->eventDispatcher->listen('Illuminate\Cache\Events\CacheHit', function ($event) use ($that) {
+			$this->registerQuery([ 'type' => 'hit', 'key' => $event->key, 'value' => $event->value ]);
+		});
+		$this->eventDispatcher->listen('Illuminate\Cache\Events\CacheMissed', function ($event) use ($that) {
+			$this->registerQuery([ 'type' => 'miss', 'key' => $event->key ]);
+		});
+		$this->eventDispatcher->listen('Illuminate\Cache\Events\KeyWritten', function ($event) use ($that) {
+			$this->registerQuery([
+				'type' => 'write', 'key' => $event->key, 'value' => $event->value, 'expiration' => $event->minutes * 60
+			]);
+		});
+		$this->eventDispatcher->listen('Illuminate\Cache\Events\KeyForgotten', function ($event) use ($that) {
+			$this->registerQuery([ 'type' => 'delete', 'key' => $event->key ]);
+		});
+	}
+
+	/**
+	 * Adds cache queries and stats to the request
+	 */
+	public function resolve(Request $request)
+	{
+		$request->cacheQueries = array_merge($request->cacheQueries, $this->getQueries());
+		$request->cacheReads = $request->cacheReads + $this->getCacheReads();
+		$request->cacheHits = $request->cacheHits + $this->getCacheHits();
+		$request->cacheWrites = $request->cacheWrites + $this->getCacheWrites();
+		$request->cacheDeletes = $request->cacheDeletes + $this->getCacheDeletes();
+
+		return $request;
+	}
+
+	/**
+	 * Registers a new query, resolves caller file and line no
+	 */
+	public function registerQuery(array $query)
+	{
+		$caller = StackTrace::get()->firstNonVendor(array('itsgoingd', 'laravel', 'illuminate'));
+
+		$this->queries[] = array_merge($query, [
+			'file' => $caller->shortPath,
+			'line' => $caller->line
+		]);
+	}
+
+	/**
+	 * Returns an array of cache queries in Clockwork metadata format
+	 */
+	protected function getQueries()
+	{
+		$that = $this;
+
+		return array_map(function ($query) use ($that) {
+			return array_merge($query, [
+				'connection' => null,
+				'time' => null,
+				'value' => isset($query['value']) ? $that->serialize($query['value']) : null
+			]);
+		}, $this->queries);
+	}
+
+	/**
+	 * Returns a number of cache reads (hits + misses)
+	 */
+	protected function getCacheReads()
+	{
+		return count(array_filter($this->queries, function ($query) {
+			return $query['type'] == 'hit' || $query['type'] == 'miss';
+		}));
+	}
+
+	/**
+	 * Returns a number of cache hits
+	 */
+	protected function getCacheHits()
+	{
+		return count(array_filter($this->queries, function ($query) {
+			return $query['type'] == 'hit';
+		}));
+	}
+
+	/**
+	 * Returns a number of cache writes
+	 */
+	protected function getCacheWrites()
+	{
+		return count(array_filter($this->queries, function ($query) {
+			return $query['type'] == 'write';
+		}));
+	}
+
+	/**
+	 * Returns a number of cache deletes
+	 */
+	protected function getCacheDeletes()
+	{
+		return count(array_filter($this->queries, function ($query) {
+			return $query['type'] == 'delete';
+		}));
+	}
+}

--- a/Clockwork/Request/Request.php
+++ b/Clockwork/Request/Request.php
@@ -77,6 +77,36 @@ class Request
 	public $databaseQueries = array();
 
 	/**
+	 * Cache queries array
+	 */
+	public $cacheQueries = array();
+
+	/**
+	 * Cache reads count
+	 */
+	public $cacheReads;
+
+	/**
+	 * Cache hits count
+	 */
+	public $cacheHits;
+
+	/**
+	 * Cache writes count
+	 */
+	public $cacheWrites;
+
+	/**
+	 * Cache deletes count
+	 */
+	public $cacheDeletes;
+
+	/**
+	 * Cache time
+	 */
+	public $cacheTime;
+
+	/**
 	 * Timeline data array
 	 */
 	public $timelineData = array();
@@ -163,6 +193,12 @@ class Request
 			'responseDuration' => $this->getResponseDuration(),
 			'databaseQueries'  => $this->databaseQueries,
 			'databaseDuration' => $this->getDatabaseDuration(),
+			'cacheQueries'     => $this->cacheQueries,
+			'cacheReads'       => $this->cacheReads,
+			'cacheHits'        => $this->cacheHits,
+			'cacheWrites'      => $this->cacheWrites,
+			'cacheDeletes'     => $this->cacheDeletes,
+			'cacheTime'        => $this->cacheTime,
 			'timelineData'     => $this->timelineData,
 			'log'              => array_values($this->log),
 			'routes'           => $this->routes,

--- a/Clockwork/Support/Laravel/ClockworkSupport.php
+++ b/Clockwork/Support/Laravel/ClockworkSupport.php
@@ -59,7 +59,6 @@ class ClockworkSupport
 			}
 
 			$storage = new SqlStorage($database, $table);
-			$storage->initialize();
 		} else {
 			$storage = new FileStorage($this->getConfig('storage_files_path', storage_path('clockwork')));
 		}
@@ -138,6 +137,11 @@ class ClockworkSupport
 	public function isCollectingDatabaseQueries()
 	{
 		return $this->app['config']->get('database.default') && !in_array('databaseQueries', $this->getFilter());
+	}
+
+	public function isCollectingCacheStats()
+	{
+		return ! in_array('cache', $this->getFilter());
 	}
 
 	protected function appendServerTimingHeader($response, $request)


### PR DESCRIPTION
- added support for collecting basic cache stats like reads, hits, writes, deletes, time
- added support for collecting full cache queries, including keys, values, expiration, connection, caller file and line no
- added data source for Laravel cache and overall Laravel support
- reworked SQL storage to support lazy schema initialization and upgrades
    - when schema changes, the existing table is renamed to `TABLE_backup_DATE` and a new table will be created
