### PR TITLE
Server-Timing support tweaks

### DIFF
--- a/Clockwork/Helpers/ServerTiming.php
+++ b/Clockwork/Helpers/ServerTiming.php
@@ -24,15 +24,15 @@ class ServerTiming
 	{
 		$header = new static;
 
-		$header->add('app', $request->getResponseDuration() / 1000, 'Application');
+		$header->add('app', $request->getResponseDuration(), 'Application');
 
 		if ($request->getDatabaseDuration()) {
-			$header->add('db', $request->getDatabaseDuration() / 1000, 'Database');
+			$header->add('db', $request->getDatabaseDuration(), 'Database');
 		}
 
 		// add timeline events limited to a set number so the header doesn't get too large
 		foreach (array_slice($request->timelineData, 0, $eventsCount) as $i => $event) {
-			$header->add("timeline-event-{$i}", $event['duration'] / 1000, $event['description']);
+			$header->add("timeline-event-{$i}", $event['duration'], $event['description']);
 		}
 
 		return $header;

--- a/Clockwork/Helpers/ServerTiming.php
+++ b/Clockwork/Helpers/ServerTiming.php
@@ -20,7 +20,7 @@ class ServerTiming
 		}, $this->metrics));
 	}
 
-	public static function fromRequest(Request $request)
+	public static function fromRequest(Request $request, $eventsCount = 10)
 	{
 		$header = new static;
 
@@ -30,8 +30,8 @@ class ServerTiming
 			$header->add('db', $request->getDatabaseDuration() / 1000, 'Database');
 		}
 
-		// add timeline events limited to first 20 events so the header doesn't get too large
-		foreach (array_slice($request->timelineData, 0, 20) as $i => $event) {
+		// add timeline events limited to a set number so the header doesn't get too large
+		foreach (array_slice($request->timelineData, 0, $eventsCount) as $i => $event) {
 			$header->add("timeline-event-{$i}", $event['duration'] / 1000, $event['description']);
 		}
 

--- a/Clockwork/Support/Laravel/ClockworkSupport.php
+++ b/Clockwork/Support/Laravel/ClockworkSupport.php
@@ -142,6 +142,8 @@ class ClockworkSupport
 
 	protected function appendServerTimingHeader($response, $request)
 	{
-		$response->headers->set('Server-Timing', ServerTiming::fromRequest($request)->value());
+		if (($eventsCount = $this->getConfig('server_timing', 10)) !== false) {
+			$response->headers->set('Server-Timing', ServerTiming::fromRequest($request, $eventsCount)->value());
+		}
 	}
 }

--- a/Clockwork/Support/Laravel/config/clockwork.php
+++ b/Clockwork/Support/Laravel/config/clockwork.php
@@ -131,6 +131,23 @@ return array(
 
 	'headers' => array(
 		// 'Accept' => 'application/vnd.com.whatever.v1+json',
-	)
+	),
+
+	/*
+	|--------------------------------------------------------------------------
+	| Server-Timing
+	|--------------------------------------------------------------------------
+	|
+	| Clockwork supports the W3C Server Timing specification, which allows for
+	/ collecting a simple performance metrics in a cross-browser way. Eg. in
+	/ Chrome, your app, database and timeline event timings will be shown
+	/ in the Dev Tools network tab.
+	/ This setting specifies the max number of timeline events that will be sent.
+	| When set to false, Server-Timing headers will not be set.
+	| Default: 10
+	|
+	*/
+
+	'server_timing' => 10
 
 );

--- a/Clockwork/Support/Lumen/ClockworkSupport.php
+++ b/Clockwork/Support/Lumen/ClockworkSupport.php
@@ -142,6 +142,8 @@ class ClockworkSupport
 
 	protected function appendServerTimingHeader($response, $request)
 	{
-		$response->headers->set('Server-Timing', ServerTiming::fromRequest($request)->value());
+		if (($eventsCount = $this->getConfig('server_timing', 10)) !== false) {
+			$response->headers->set('Server-Timing', ServerTiming::fromRequest($request, $eventsCount)->value());
+		}
 	}
 }


### PR DESCRIPTION
A few tweaks for Server-Timing support (https://github.com/itsgoingd/clockwork/issues/125) before release:

- number of sent timeline events is now configurable in Laravel and Lumen (default lowered to 10)
- setting the option to `false` disables sending the Server-Timing headers
- updated to send the values in milliseconds to match latest Chrome