### PR TITLE
Reworked storage api

### DIFF
--- a/Clockwork/Storage/Storage.php
+++ b/Clockwork/Storage/Storage.php
@@ -3,39 +3,12 @@
 use Clockwork\Storage\StorageInterface;
 use Clockwork\Request\Request;
 
-/**
- * Base storage class, all storages have to extend this class
- */
 abstract class Storage implements StorageInterface
 {
-	/**
-	 * Array of data to be filtered from stored requests
-	 */
+	// Array of data to be filtered from stored requests
 	public $filter = [];
 
-	/**
-	 * Same as retrieve, but json representations of requests are returned
-	 */
-	public function retrieveAsJson($id = null, $last = null)
-	{
-		$requests = $this->retrieve($id, $last);
-
-		if (! $requests) {
-			return null;
-		}
-
-		if (! is_array($requests)) {
-			return $requests->toJson();
-		}
-
-		return json_encode(array_map(function ($request) {
-			return $request->toArray();
-		}));
-	}
-
-	/**
-	 * Return array of data with applied filter
-	 */
+	// Return array of data with applied filter
 	protected function applyFilter(array $data)
 	{
 		$emptyRequest = new Request([]);

--- a/Clockwork/Storage/StorageInterface.php
+++ b/Clockwork/Storage/StorageInterface.php
@@ -3,18 +3,25 @@
 use Clockwork\Request\Request;
 
 /**
- * Base storage class, all storages have to extend this class
+ * Interface for requests storage implementations
  */
 interface StorageInterface
 {
-	/**
-	 * Retrieve request specified by id argument, if second argument is specified, array of requests from id to last
-	 * will be returned
-	 */
-	public function retrieve($id = null, $last = null);
+	// Returns all requests
+	public function all();
 
-	/**
-	 * Store request
-	 */
+	// Return a single request by id
+	public function find($id);
+
+	// Return the latest request
+	public function latest();
+
+	// Return requests received before specified id, optionally limited to specified count
+	public function previous($id, $count = null);
+
+	// Return requests received after specified id, optionally limited to specified count
+	public function next($id, $count = null);
+
+	// Store request
 	public function store(Request $request);
 }

--- a/Clockwork/Support/Laravel/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Laravel/ClockworkServiceProvider.php
@@ -33,11 +33,14 @@ class ClockworkServiceProvider extends ServiceProvider
 		}
 
 		if ($this->isLegacyLaravel()) {
-			$this->app['router']->get('/__clockwork/{id}', 'Clockwork\Support\Laravel\Controllers\LegacyController@getData')->where('id', '[0-9\.]+');
+			$this->app['router']->get('/__clockwork/{id}/{direction?}/{count?}', 'Clockwork\Support\Laravel\Controllers\LegacyController@getData')
+				->where('id', '([0-9\.]+|latest)')->where('direction', '(next|previous)')->where('count', '\d+');
 		} elseif ($this->isOldLaravel()) {
-			$this->app['router']->get('/__clockwork/{id}', 'Clockwork\Support\Laravel\Controllers\OldController@getData')->where('id', '[0-9\.]+');
+			$this->app['router']->get('/__clockwork/{id}/{direction?}/{count?}', 'Clockwork\Support\Laravel\Controllers\OldController@getData')
+				->where('id', '([0-9\.]+|latest)')->where('direction', '(next|previous)')->where('count', '\d+');
 		} else {
-			$this->app['router']->get('/__clockwork/{id}', 'Clockwork\Support\Laravel\Controllers\CurrentController@getData')->where('id', '[0-9\.]+');
+			$this->app['router']->get('/__clockwork/{id}/{direction?}/{count?}', 'Clockwork\Support\Laravel\Controllers\CurrentController@getData')
+				->where('id', '([0-9\.]+|latest)')->where('direction', '(next|previous)')->where('count', '\d+');
 		}
 	}
 

--- a/Clockwork/Support/Laravel/ClockworkSupport.php
+++ b/Clockwork/Support/Laravel/ClockworkSupport.php
@@ -39,11 +39,23 @@ class ClockworkSupport
 		}
 	}
 
-	public function getData($id = null, $last = null)
+	public function getData($id = null, $direction = null, $count = null)
 	{
 		$this->app['session.store']->reflash();
 
-		return new JsonResponse($this->app['clockwork']->getStorage()->retrieve($id, $last));
+		$storage = $this->app['clockwork']->getStorage();
+
+		if ($direction == 'previous') {
+			$data = $storage->previous($id, $count);
+		} elseif ($direction == 'next') {
+			$data = $storage->next($id, $count);
+		} elseif ($id == 'latest') {
+			$data = $storage->latest();
+		} else {
+			$data = $storage->find($id);
+		}
+
+		return new JsonResponse($data);
 	}
 
 	public function getStorage()

--- a/Clockwork/Support/Laravel/Controllers/CurrentController.php
+++ b/Clockwork/Support/Laravel/Controllers/CurrentController.php
@@ -12,8 +12,8 @@ class CurrentController extends Controller
 		$this->app = $app;
 	}
 
-	public function getData($id = null, $last = null)
+	public function getData($id = null, $direction = null, $count = null)
 	{
-		return $this->app['clockwork.support']->getData($id, $last);
+		return $this->app['clockwork.support']->getData($id, $direction, $count);
 	}
 }

--- a/Clockwork/Support/Laravel/Controllers/LegacyController.php
+++ b/Clockwork/Support/Laravel/Controllers/LegacyController.php
@@ -12,8 +12,8 @@ class LegacyController extends Controller
 		$this->app = $app;
 	}
 
-	public function getData($id = null, $last = null)
+	public function getData($id = null, $direction = null, $count = null)
 	{
-		return $this->app['clockwork.support']->getData($id, $last);
+		return $this->app['clockwork.support']->getData($id, $direction, $count);
 	}
 }

--- a/Clockwork/Support/Laravel/Controllers/OldController.php
+++ b/Clockwork/Support/Laravel/Controllers/OldController.php
@@ -11,8 +11,8 @@ class OldController extends Controller
 		$this->app = app();
 	}
 
-	public function getData($id = null, $last = null)
+	public function getData($id = null, $direction = null, $count = null)
 	{
-		return $this->app['clockwork.support']->getData($id, $last);
+		return $this->app['clockwork.support']->getData($id, $direction, $count);
 	}
 }

--- a/Clockwork/Support/Lumen/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Lumen/ClockworkServiceProvider.php
@@ -33,7 +33,8 @@ class ClockworkServiceProvider extends ServiceProvider
 			return; // Clockwork is disabled, don't register the route
 		}
 
-		$this->app->get('/__clockwork/{id}', 'Clockwork\Support\Lumen\Controller@getData');
+		$this->app->get('/__clockwork/{id}/{direction?}/{count?}', 'Clockwork\Support\Lumen\Controller@getData')
+			->where('id', '[0-9\.]+')->where('direction', '(next|previous)')->where('count', '\d+');
 	}
 
 	public function register()

--- a/Clockwork/Support/Lumen/ClockworkSupport.php
+++ b/Clockwork/Support/Lumen/ClockworkSupport.php
@@ -28,13 +28,25 @@ class ClockworkSupport
 		return env('CLOCKWORK_' . strtoupper($key), $default);
 	}
 
-	public function getData($id = null, $last = null)
+	public function getData($id = null, $direction = null, $count = null)
 	{
 		if (isset($this->app['session'])) {
 			$this->app['session.store']->reflash();
 		}
 
-		return new JsonResponse($this->app['clockwork']->getStorage()->retrieve($id, $last));
+		$storage = $this->app['clockwork']->getStorage();
+
+		if ($direction == 'previous') {
+			$data = $storage->previous($id, $count);
+		} elseif ($direction == 'next') {
+			$data = $storage->next($id, $count);
+		} elseif ($id == 'latest') {
+			$data = $storage->latest();
+		} else {
+			$data = $storage->find($id);
+		}
+
+		return new JsonResponse($data);
 	}
 
 	public function getStorage()

--- a/Clockwork/Support/Lumen/Controller.php
+++ b/Clockwork/Support/Lumen/Controller.php
@@ -13,8 +13,8 @@ class Controller extends LumenController
 		$this->clockworkSupport = $clockworkSupport;
 	}
 
-	public function getData($id = null, $last = null)
+	public function getData($id = null, $direction = null, $count = null)
 	{
-		return $this->clockworkSupport->getData($id, $last);
+		return $this->clockworkSupport->getData($id, $direction, $count);
 	}
 }


### PR DESCRIPTION
New storage api interface:

- `all()`
    - returns all requests
- `find($id)`
    - returns single request specified by id
- `latest()`
    - returns latest request
- `previous($id, $count = null)`
    - return requests received before specified id, optionally limited to specified count
- `next($id, $count = null)`
    - return requests received after specified id, optionally limited to specified count

The Clockwork metadata route changes like this:

`/__clockwork/{id}/{direction?}/{count?}`

- id - request id or `latest` for latest request
- direction - previous or next (optional)
- count - number of previous or next requests (optional)

Note, this is compatible with existing clients as all the extra arguments are optional.
