### PR TITLE
Laravel automatically register middleware

### DIFF
--- a/Clockwork/Support/Laravel/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Laravel/ClockworkServiceProvider.php
@@ -32,6 +32,8 @@ class ClockworkServiceProvider extends ServiceProvider
 			return; // Clockwork is disabled, don't register the route
 		}
 
+		$this->registerMiddleware();
+
 		if ($this->isLegacyLaravel()) {
 			$this->app['router']->get('/__clockwork/{id}', 'Clockwork\Support\Laravel\Controllers\LegacyController@getData')->where('id', '[0-9\.]+');
 		} elseif ($this->isOldLaravel()) {
@@ -112,24 +114,29 @@ class ClockworkServiceProvider extends ServiceProvider
 		if ($this->app['clockwork.support']->getConfig('register_helpers', true)) {
 			require __DIR__ . '/helpers.php';
 		}
+	}
 
+	// Register the artisan commands.
+	public function registerCommands()
+	{
+		$this->commands([
+			'Clockwork\Support\Laravel\ClockworkCleanCommand'
+		]);
+	}
+
+	// Register middleware
+	public function registerMiddleware()
+	{
 		if ($this->isLegacyLaravel()) {
 			$this->app->middleware('Clockwork\Support\Laravel\ClockworkLegacyMiddleware', [ $this->app ]);
 		} elseif ($this->isOldLaravel()) {
 			$this->app['router']->after(function ($request, $response) {
 				return $this->app['clockwork.support']->process($request, $response);
 			});
+		} else {
+			$kernel = $this->app['Illuminate\Contracts\Http\Kernel'];
+			$kernel->prependMiddleware('Clockwork\Support\Laravel\ClockworkMiddleware');
 		}
-	}
-
-	/**
-	 * Register the artisan commands.
-	 */
-	public function registerCommands()
-	{
-		$this->commands([
-			'Clockwork\Support\Laravel\ClockworkCleanCommand'
-		]);
 	}
 
 	public function provides()


### PR DESCRIPTION
Laravel middleware will now be automatically registered in the service provider.

This also makes auto-discovery work in Laravel 5.5.