### PR TITLE
Fix DoctrineDataSource query duration, use milliseconds not seconds

### DIFF
--- a/Clockwork/DataSource/DoctrineDataSource.php
+++ b/Clockwork/DataSource/DoctrineDataSource.php
@@ -108,20 +108,20 @@ class DoctrineDataSource extends DataSource implements SQLLogger
 	 */
 	public function stopQuery()
 	{
-		$endTime = microtime(true) - $this->start;
+		$duration = (microtime(true) - $this->start) * 1000;
 
-		$this->registerQuery($this->query['sql'], $this->query['params'], $endTime, $this->connection->getDatabase());
+		$this->registerQuery($this->query['sql'], $this->query['params'], $duration, $this->connection->getDatabase());
 	}
 
 	/**
 	 * Log the query into the internal store
 	 */
-	public function registerQuery($query, $bindings, $time, $connection)
+	public function registerQuery($query, $bindings, $duration, $connection)
 	{
 		$this->queries[] = [
 			'query'      => $query,
 			'bindings'   => $bindings,
-			'duration'   => $time,
+			'duration'   => $duration,
 			'connection' => $connection
 		];
 	}


### PR DESCRIPTION
Query duration was reported in seconds, so 1000 times faster then actual request time.

I also changed the variable name to make it clearer.