### PR TITLE
Fix SqlStorage PostgreSQL compatibility

### DIFF
--- a/Clockwork/Request/Request.php
+++ b/Clockwork/Request/Request.php
@@ -175,6 +175,7 @@ class Request
 	{
 		return [
 			'id'               => $this->id,
+			'version'          => $this->version,
 			'time'             => $this->time,
 			'method'           => $this->method,
 			'uri'              => $this->uri,


### PR DESCRIPTION
Fixed SqlStorage compatibility with PostgreSQL.

- use proper data types in the schema depending on used database
- added quoting of identifiers (required for case-sensitive column names in pgsql)
- improve error handling in the query method (prepare call doesn't do error checking on pgsql)

Fixed Clockwork library version being stored instead of the metadata version (leading to invalid integer value).

Fixes https://github.com/itsgoingd/clockwork/issues/176