### PR TITLE
Storage cleanup support

### DIFF
--- a/Clockwork/Storage/StorageInterface.php
+++ b/Clockwork/Storage/StorageInterface.php
@@ -24,4 +24,7 @@ interface StorageInterface
 
 	// Store request
 	public function store(Request $request);
+
+	// Cleanup old requests
+	public function cleanup();
 }

--- a/Clockwork/Support/Laravel/ClockworkSupport.php
+++ b/Clockwork/Support/Laravel/ClockworkSupport.php
@@ -60,6 +60,8 @@ class ClockworkSupport
 
 	public function getStorage()
 	{
+		$expiration = $this->getConfig('storage_expiration');
+
 		if ($this->getConfig('storage', 'files') == 'sql') {
 			$database = $this->getConfig('storage_sql_database', storage_path('clockwork.sqlite'));
 			$table = $this->getConfig('storage_sql_table', 'clockwork');
@@ -70,9 +72,11 @@ class ClockworkSupport
 				$database = "sqlite:{$database}";
 			}
 
-			$storage = new SqlStorage($database, $table);
+			$storage = new SqlStorage($database, $table, null, null, $expiration);
 		} else {
-			$storage = new FileStorage($this->getConfig('storage_files_path', storage_path('clockwork')));
+			$storage = new FileStorage(
+				$this->getConfig('storage_files_path', storage_path('clockwork')), 0700, $expiration
+			);
 		}
 
 		$storage->filter = $this->getFilter();

--- a/Clockwork/Support/Laravel/config/clockwork.php
+++ b/Clockwork/Support/Laravel/config/clockwork.php
@@ -56,6 +56,20 @@ return array(
 
 	/*
 	|--------------------------------------------------------------------------
+	| Metadata expiration
+	|--------------------------------------------------------------------------
+	|
+	| Maximum lifetime of the metadata in seconds, metadata for older requests
+	| will automatically be deleted when storing new requests.
+	| When set to false, metadata will never be deleted.
+	| Default: about a month
+	|
+	*/
+
+	'storage_expiration' => 60 * 24 * 30,
+
+	/*
+	|--------------------------------------------------------------------------
 	| Filter collected data
 	|--------------------------------------------------------------------------
 	|

--- a/Clockwork/Support/Lumen/ClockworkSupport.php
+++ b/Clockwork/Support/Lumen/ClockworkSupport.php
@@ -51,6 +51,8 @@ class ClockworkSupport
 
 	public function getStorage()
 	{
+		$expiration = $this->getConfig('storage_expiration');
+
 		if ($this->getConfig('storage', 'files') == 'sql') {
 			$database = $this->getConfig('storage_sql_database', storage_path('clockwork.sqlite'));
 			$table = $this->getConfig('storage_sql_table', 'clockwork');
@@ -61,10 +63,11 @@ class ClockworkSupport
 				$database = "sqlite:{$database}";
 			}
 
-			$storage = new SqlStorage($database, $table);
-			$storage->initialize();
+			$storage = new SqlStorage($database, $table, null, null, $expiration);
 		} else {
-			$storage = new FileStorage($this->getConfig('storage_files_path', storage_path('clockwork')));
+			$storage = new FileStorage(
+				$this->getConfig('storage_files_path', storage_path('clockwork')), 0700, $expiration
+			);
 		}
 
 		$storage->filter = $this->getFilter();


### PR DESCRIPTION
Adds support for cleaning up old metadata.

Storage interface gets a new `cleanup` method, it's up to storage implementation how the cleanup process is done. The default storage classes do cleanup based on specified expiration time when storing a new request, defaults to 1 month.

This needs some benchmarks, I've noticed inserting data to a large Sqlite database an be VERY slow.

- is sqlite storage fast enough in comparison to file storage?
- how many requests do we store by default to be fast enough and keep the data size low enough?
- do we need the cleanup lottery in file storage since we are not actually reading and parsing the files? (and sql storage?)
