### PR TITLE
Disable collecting data for artisan commands

### DIFF
--- a/Clockwork/Support/Laravel/ClockworkSupport.php
+++ b/Clockwork/Support/Laravel/ClockworkSupport.php
@@ -142,7 +142,7 @@ class ClockworkSupport
 
 	public function isCollectingData()
 	{
-		return $this->isEnabled() || $this->getConfig('collect_data_always', false);
+		return ($this->isEnabled() || $this->getConfig('collect_data_always', false)) && ! $this->app->runningInConsole();
 	}
 
 	public function isCollectingDatabaseQueries()

--- a/Clockwork/Support/Lumen/ClockworkSupport.php
+++ b/Clockwork/Support/Lumen/ClockworkSupport.php
@@ -138,7 +138,7 @@ class ClockworkSupport
 
 	public function isCollectingData()
 	{
-		return $this->isEnabled() || $this->getConfig('collect_data_always', false);
+		return ($this->isEnabled() || $this->getConfig('collect_data_always', false)) && ! $this->app->runningInConsole();
 	}
 
 	public function isCollectingDatabaseQueries()


### PR DESCRIPTION
- disabled collecting data when running artisan commands, as this adds unnecessary performance overhead and the data is not even used in any way