### PR TITLE
Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ protected $middleware = [
 	...
 ]
 ```
+Note: If you are using Laravels route caching you will need to clear the cache using the `php artisan route:cache` as Clockwork adds its own routes for retrieving the data.
 
 By default, Clockwork will only be available in debug mode, you can change this and other settings in the configuration file. Use the following Artisan command to publish the configuration file into your config directory:
 


### PR DESCRIPTION
I was not aware that Clockwork added routes for retrieving its stats.

I've added note about laravel route caching which caused me to see nothing in the dev tools tab (not even any errors)