### PR TITLE
Change fire() method to handle() for use with Laravel 5.5

### DIFF
--- a/Clockwork/Support/Laravel/ClockworkCleanCommand.php
+++ b/Clockwork/Support/Laravel/ClockworkCleanCommand.php
@@ -42,7 +42,7 @@ class ClockworkCleanCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $data_dir = storage_path() . '/clockwork';
 


### PR DESCRIPTION
Due to a recent [update](https://github.com/laravel/framework/commit/ac9f29da4785c8b942ced8c4ab308214d618a22b) for Laravel 5.5 the `fire()` method will no longer work for console commands. 

`handle()` now seems to be the only method that can be used.

This update requires Laravel 5.*
