### PR TITLE
Refactor clock() helper

### DIFF
--- a/Clockwork/Support/Laravel/helpers.php
+++ b/Clockwork/Support/Laravel/helpers.php
@@ -1,22 +1,19 @@
 <?php
 
 if (! function_exists('clock')) {
-	// workaround so we can log null values with the helepr function
-	if (! defined('CLOCKWORK_NULL')) {
-		define('CLOCKWORK_NULL', sha1(time()));
-	}
-
 	/**
 	 * Log a message to Clockwork, returns Clockwork instance when called with no arguments.
 	 */
-	function clock($message = CLOCKWORK_NULL)
+	function clock()
 	{
-		if ($message === CLOCKWORK_NULL) {
+		$arguments = func_get_args();
+
+		if (empty($arguments)) {
 			return app('clockwork');
-		} else {
-			foreach (func_get_args() as $arg) {
-				app('clockwork')->debug($arg);
-			}
+		}
+
+		foreach ($arguments as $argument) {
+			app('clockwork')->debug($argument);
 		}
 	}
 }

--- a/Clockwork/Support/Lumen/helpers.php
+++ b/Clockwork/Support/Lumen/helpers.php
@@ -1,22 +1,19 @@
 <?php
 
 if (! function_exists('clock')) {
-	// workaround so we can log null values with the helepr function
-	if (! defined('CLOCKWORK_NULL')) {
-		define('CLOCKWORK_NULL', sha1(time()));
-	}
-
 	/**
 	 * Log a message to Clockwork, returns Clockwork instance when called with no arguments.
 	 */
-	function clock($message = CLOCKWORK_NULL)
+	function clock()
 	{
-		if ($message === CLOCKWORK_NULL) {
+		$arguments = func_get_args();
+
+		if (empty($arguments)) {
 			return app('clockwork');
-		} else {
-			foreach (func_get_args() as $arg) {
-				app('clockwork')->debug($arg);
-			}
+		}
+
+		foreach ($arguments as $argument) {
+			app('clockwork')->debug($argument);
 		}
 	}
 }


### PR DESCRIPTION
This PR cleans up the `clock()` helper used in Laravel/Lumen. It removes the hacky `CLOCKWORK_NULL` workaround.

🌵 