### PR TITLE
Add backwards-compatible support for lumen 5.5

### DIFF
--- a/Clockwork/Support/Lumen/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Lumen/ClockworkServiceProvider.php
@@ -33,7 +33,11 @@ class ClockworkServiceProvider extends ServiceProvider
 			return; // Clockwork is disabled, don't register the route
 		}
 
-		$this->app->get('/__clockwork/{id}', 'Clockwork\Support\Lumen\Controller@getData');
+		if (isset($this->app->router)) {
+			$this->app->router->get('/__clockwork/{id}', 'Clockwork\Support\Lumen\Controller@getData');
+		} else {
+			$this->app->get('/__clockwork/{id}', 'Clockwork\Support\Lumen\Controller@getData');
+		}
 	}
 
 	public function register()


### PR DESCRIPTION
https://lumen.laravel.com/docs/5.5/upgrade#upgrade-5.5.0

As per the Laravel documentation, `$app->get()` now resolves out of the container instead of proxying to the underlying router. Because both Lumen 5.4 and Lumen 5.5 both expose the `$router` publicly, this is a backwards-compatible fix.

Currently this plugin breaks Lumen 5.5 until it is removed. You are given an exception that the container could not find an entry for `/__clockwork/{id}`.