### PR TITLE
Changed the dots in request ids to dashes.

### DIFF
--- a/Clockwork/Request/Request.php
+++ b/Clockwork/Request/Request.php
@@ -224,6 +224,6 @@ class Request
 	 */
 	protected function generateRequestId()
 	{
-		return sprintf('%.4F', microtime(true)) . '.' . mt_rand();
+		return str_replace('.', '-', sprintf('%.4F', microtime(true))) . '-' . mt_rand();
 	}
 }

--- a/Clockwork/Storage/FileStorage.php
+++ b/Clockwork/Storage/FileStorage.php
@@ -98,8 +98,8 @@ class FileStorage extends Storage
 		$expirationTime = time() - ($this->expiration * 60);
 
 		$ids = array_filter($this->ids(), function ($id) use ($expirationTime) {
-			preg_match('#(?<time>\d+\.\d+)\.\d+#', $id, $matches);
-			return $matches['time'] < $expirationTime;
+			preg_match('#(?<time>\d+\-\d+)\-\d+#', $id, $matches);
+			return str_replace('-', '.', $matches['time']) < $expirationTime;
 		});
 
 		foreach ($ids as $id) {

--- a/Clockwork/Support/Laravel/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Laravel/ClockworkServiceProvider.php
@@ -158,13 +158,13 @@ class ClockworkServiceProvider extends ServiceProvider
 	{
 		if ($this->isLegacyLaravel()) {
 			$this->app['router']->get('/__clockwork/{id}/{direction?}/{count?}', 'Clockwork\Support\Laravel\Controllers\LegacyController@getData')
-				->where('id', '([0-9\.]+|latest)')->where('direction', '(next|previous)')->where('count', '\d+');
+				->where('id', '([0-9-]+|latest)')->where('direction', '(next|previous)')->where('count', '\d+');
 		} elseif ($this->isOldLaravel()) {
 			$this->app['router']->get('/__clockwork/{id}/{direction?}/{count?}', 'Clockwork\Support\Laravel\Controllers\OldController@getData')
-				->where('id', '([0-9\.]+|latest)')->where('direction', '(next|previous)')->where('count', '\d+');
+				->where('id', '([0-9-]+|latest)')->where('direction', '(next|previous)')->where('count', '\d+');
 		} else {
 			$this->app['router']->get('/__clockwork/{id}/{direction?}/{count?}', 'Clockwork\Support\Laravel\Controllers\CurrentController@getData')
-				->where('id', '([0-9\.]+|latest)')->where('direction', '(next|previous)')->where('count', '\d+');
+				->where('id', '([0-9-]+|latest)')->where('direction', '(next|previous)')->where('count', '\d+');
 		}
 	}
 

--- a/Clockwork/Support/Lumen/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Lumen/ClockworkServiceProvider.php
@@ -37,7 +37,7 @@ class ClockworkServiceProvider extends ServiceProvider
 		$router = isset($this->app->router) ? $this->app->router : $this->app;
 
 		$router->get('/__clockwork/{id}/{direction?}/{count?}', 'Clockwork\Support\Lumen\Controller@getData')
-			->where('id', '[0-9\.]+')->where('direction', '(next|previous)')->where('count', '\d+');
+			->where('id', '[0-9-]+')->where('direction', '(next|previous)')->where('count', '\d+');
 	}
 
 	public function register()

--- a/Clockwork/Support/Slim/ClockworkMiddleware.php
+++ b/Clockwork/Support/Slim/ClockworkMiddleware.php
@@ -27,10 +27,8 @@ class ClockworkMiddleware
 
     public function process(Request $request, Response $response, callable $next)
     {
-        $clockworkDataUri = '#/__clockwork(?:/(?<id>[0-9\.]+))?(?:/(?<direction>(?:previous|next)))?(?:/(?<count>\d+))?#';
-        // use both base path and path here as path is set incorrectly when the URI contains dot (at least with php built-in server)
-        $path = $request->getUri()->getBasePath() . $request->getUri()->getPath();
-		if (preg_match($clockworkDataUri, $path, $matches)) {
+        $clockworkDataUri = '#/__clockwork(?:/(?<id>[0-9-]+))?(?:/(?<direction>(?:previous|next)))?(?:/(?<count>\d+))?#';
+		if (preg_match($clockworkDataUri, $request->getUri()->getPath(), $matches)) {
             $matches = array_merge([ 'direction' => null, 'count' => null ], $matches);
 			return $this->retrieveRequest($response, $matches['id'], $matches['direction'], $matches['count']);
 		}

--- a/Clockwork/Support/Slim/Legacy/ClockworkMiddleware.php
+++ b/Clockwork/Support/Slim/Legacy/ClockworkMiddleware.php
@@ -38,7 +38,7 @@ class ClockworkMiddleware extends Middleware
 
 		$this->app->getLog()->setWriter($clockworkLogWriter);
 
-		$clockworkDataUri = '#/__clockwork(?:/(?<id>[0-9\.]+))?(?:/(?<direction>(?:previous|next)))?(?:/(?<count>\d+))?#';
+		$clockworkDataUri = '#/__clockwork(?:/(?<id>[0-9-]+))?(?:/(?<direction>(?:previous|next)))?(?:/(?<count>\d+))?#';
 		if ($this->app->config('debug') && preg_match($clockworkDataUri, $this->app->request()->getPathInfo(), $matches)) {
 			$matches = array_merge([ 'direction' => null, 'count' => null ], $matches);
 			return $this->retrieveRequest($matches['id'], $matches['direction'], $matches['count']);


### PR DESCRIPTION
- replaces dots in the request ids with dashes, eg. `1506684439.6859.1387971986` to `1506684439-6859-1387971986`
- this is done mainly to support the integrated php development server which doesn't handle urls with dots very well
- fixes https://github.com/itsgoingd/clockwork/issues/198