### PR TITLE
Prevent mkdir() from throwing its own exception, 

### DIFF
--- a/Clockwork/Storage/FileStorage.php
+++ b/Clockwork/Storage/FileStorage.php
@@ -22,7 +22,7 @@ class FileStorage extends Storage
 	{
 		if (! file_exists($path)) {
 			// directory doesn't exist, try to create one
-			if (! mkdir($path, $dirPermissions, true)) {
+			if (! @mkdir($path, $dirPermissions, true)) {
 				throw new \Exception("Directory \"{$path}\" does not exist.");
 			}
 


### PR DESCRIPTION
... which is less helpful as it does not contain the directory name.
So you get a mkdir permission denied, but are not told which directory. Adding a `@` prevents mkdir from throwing an exception, and lets the clockwork throw the exception.

Because I have SELinux enabled, after knowing the directory name, I could:
```
chcon -Rv --type=httpd_sys_rw_content_t ./storage/clockwork
chcon -Rv --type=httpd_sys_content_t ./storage/clockwork/.gitignore
```