### PR TITLE
Pull settings from app['config'] instead of env()

### DIFF
--- a/Clockwork/Support/Lumen/ClockworkSupport.php
+++ b/Clockwork/Support/Lumen/ClockworkSupport.php
@@ -23,7 +23,7 @@ class ClockworkSupport
 
 	public function getConfig($key, $default = null)
 	{
-		return env('CLOCKWORK_' . strtoupper($key), $default);
+		return $this->app['config']->get("clockwork.{$key}", $default);
 	}
 
 	public function getData($id = null, $direction = null, $count = null)


### PR DESCRIPTION
env() doesn't allow configuration of complex parameters, app['config'] does and is a drop in change