### PR TITLE
Fix path check in windows

### DIFF
--- a/Clockwork/Web/Web.php
+++ b/Clockwork/Web/Web.php
@@ -16,7 +16,7 @@ class Web
 
 	protected function resolveAssetPath($path)
 	{
-		$publicPath = __DIR__ . '/public';
+		$publicPath = realpath(__DIR__ . '/public');
 
 		$path = realpath("$publicPath/{$path}");
 


### PR DESCRIPTION
When you try to use the clockwork in windows, checking the path always returns "false" because need backslash but used slash.
![2018-01-31_092339](https://user-images.githubusercontent.com/3649525/35610346-990eb2b0-0669-11e8-9f5f-a6a143786eef.png)

With fix
![2018-01-31_093138](https://user-images.githubusercontent.com/3649525/35610348-99387fdc-0669-11e8-9761-7bfbfbc563d3.png)
