### PR TITLE
Follow the new `Server-Timing` header spec

### DIFF
--- a/Clockwork/Helpers/ServerTiming.php
+++ b/Clockwork/Helpers/ServerTiming.php
@@ -16,7 +16,7 @@ class ServerTiming
 	public function value()
 	{
 		return implode(', ', array_map(function ($metric) {
-			return "{$metric['metric']}={$metric['value']}; \"{$metric['description']}\"";
+			return "{$metric['metric']}; dur={$metric['value']}; desc=\"{$metric['description']}\"";
 		}, $this->metrics));
 	}
 


### PR DESCRIPTION
Matches the spec, which changed in https://github.com/w3c/server-timing/pull/37 and https://github.com/w3c/server-timing/pull/41

refs #244 