### PR TITLE
Add support for collecting of stack traces

### DIFF
--- a/Clockwork/DataSource/DataSource.php
+++ b/Clockwork/DataSource/DataSource.php
@@ -7,12 +7,23 @@ use Clockwork\Request\Request;
  */
 class DataSource implements DataSourceInterface
 {
+	// Whether the data source should collect stack traces (when applicable)
+	protected $collectStackTraces;
+
 	/**
 	 * Adds data to the request and returns it, custom implementation should be provided in child classes
 	 */
 	public function resolve(Request $request)
 	{
 		return $request;
+	}
+
+	// Enable or disable collecting of stack traces
+	public function collectStackTraces($enable = true)
+	{
+		$this->collectStackTraces = $enable;
+
+		return $this;
 	}
 
 	/**

--- a/Clockwork/DataSource/EloquentDataSource.php
+++ b/Clockwork/DataSource/EloquentDataSource.php
@@ -1,5 +1,6 @@
 <?php namespace Clockwork\DataSource;
 
+use Clockwork\Helpers\Serializer;
 use Clockwork\Helpers\StackTrace;
 use Clockwork\Request\Request;
 use Clockwork\Support\Laravel\Eloquent\ResolveModelScope;
@@ -66,7 +67,8 @@ class EloquentDataSource extends DataSource
 	 */
 	public function registerQuery($event)
 	{
-		$caller = StackTrace::get()->firstNonVendor([ 'itsgoingd', 'laravel', 'illuminate' ]);
+		$trace = StackTrace::get();
+		$caller = $trace->firstNonVendor([ 'itsgoingd', 'laravel', 'illuminate' ]);
 
 		$this->queries[] = [
 			'query'      => $event->sql,
@@ -75,6 +77,7 @@ class EloquentDataSource extends DataSource
 			'connection' => $event->connectionName,
 			'file'       => $caller->shortPath,
 			'line'       => $caller->line,
+			'trace'      => Serializer::trace($trace->framesBefore($caller)),
 			'model'      => $this->nextQueryModel
 		];
 
@@ -160,6 +163,7 @@ class EloquentDataSource extends DataSource
 				'connection' => $query['connection'],
 				'file'       => $query['file'],
 				'line'       => $query['line'],
+				'trace'      => $query['trace'],
 				'model'      => $query['model']
 			];
 		}, $this->queries);

--- a/Clockwork/DataSource/EloquentDataSource.php
+++ b/Clockwork/DataSource/EloquentDataSource.php
@@ -77,7 +77,7 @@ class EloquentDataSource extends DataSource
 			'connection' => $event->connectionName,
 			'file'       => $caller->shortPath,
 			'line'       => $caller->line,
-			'trace'      => Serializer::trace($trace->framesBefore($caller)),
+			'trace'      => $this->collectStackTraces ? Serializer::trace($trace->framesBefore($caller)) : null,
 			'model'      => $this->nextQueryModel
 		];
 

--- a/Clockwork/DataSource/LaravelCacheDataSource.php
+++ b/Clockwork/DataSource/LaravelCacheDataSource.php
@@ -95,7 +95,7 @@ class LaravelCacheDataSource extends DataSource
 		$this->queries[] = array_merge($query, [
 			'file'  => $caller->shortPath,
 			'line'  => $caller->line,
-			'trace' => Serializer::trace($trace->framesBefore($caller))
+			'trace' => $this->collectStackTraces ? Serializer::trace($trace->framesBefore($caller)) : null
 		]);
 	}
 

--- a/Clockwork/DataSource/LaravelCacheDataSource.php
+++ b/Clockwork/DataSource/LaravelCacheDataSource.php
@@ -89,11 +89,13 @@ class LaravelCacheDataSource extends DataSource
 	 */
 	public function registerQuery(array $query)
 	{
-		$caller = StackTrace::get()->firstNonVendor([ 'itsgoingd', 'laravel', 'illuminate' ]);
+		$trace = StackTrace::get();
+		$caller = $trace->firstNonVendor([ 'itsgoingd', 'laravel', 'illuminate' ]);
 
 		$this->queries[] = array_merge($query, [
-			'file' => $caller->shortPath,
-			'line' => $caller->line
+			'file'  => $caller->shortPath,
+			'line'  => $caller->line,
+			'trace' => Serializer::trace($trace->framesBefore($caller))
 		]);
 	}
 

--- a/Clockwork/DataSource/LaravelEventsDataSource.php
+++ b/Clockwork/DataSource/LaravelEventsDataSource.php
@@ -64,7 +64,7 @@ class LaravelEventsDataSource extends DataSource
 			'listeners' => $this->findListenersFor($event),
 			'file'      => $firedAt->shortPath,
 			'line'      => $firedAt->line,
-			'trace'     => Serializer::trace($trace->framesBefore($firedAt)),
+			'trace'     => $this->collectStackTraces ? Serializer::trace($trace->framesBefore($firedAt)) : null,
 		];
 	}
 

--- a/Clockwork/DataSource/LaravelEventsDataSource.php
+++ b/Clockwork/DataSource/LaravelEventsDataSource.php
@@ -54,7 +54,8 @@ class LaravelEventsDataSource extends DataSource
 	{
 		if (! $this->shouldCollect($event)) return;
 
-		$firedAt = StackTrace::get()->firstNonVendor([ 'itsgoingd', 'laravel', 'illuminate' ]);
+		$trace = StackTrace::get();
+		$firedAt = $trace->firstNonVendor([ 'itsgoingd', 'laravel', 'illuminate' ]);
 
 		$this->events[] = [
 			'event'     => $event,
@@ -62,7 +63,8 @@ class LaravelEventsDataSource extends DataSource
 			'time'      => microtime(true),
 			'listeners' => $this->findListenersFor($event),
 			'file'      => $firedAt->shortPath,
-			'line'      => $firedAt->line
+			'line'      => $firedAt->line,
+			'trace'     => Serializer::trace($trace->framesBefore($firedAt)),
 		];
 	}
 

--- a/Clockwork/Helpers/Serializer.php
+++ b/Clockwork/Helpers/Serializer.php
@@ -30,4 +30,16 @@ class Serializer
 
 		return $data;
 	}
+
+	public static function trace(StackTrace $trace)
+	{
+		return array_map(function ($frame) {
+			return [
+				'call' => $frame->call,
+				'file' => $frame->file,
+				'line' => $frame->line,
+				'isVendor' => $frame->isVendor
+			];
+		}, $trace->frames());
+	}
 }

--- a/Clockwork/Helpers/StackFrame.php
+++ b/Clockwork/Helpers/StackFrame.php
@@ -2,6 +2,7 @@
 
 class StackFrame
 {
+	public $call;
 	public $function;
 	public $line;
 	public $file;
@@ -10,13 +11,25 @@ class StackFrame
 	public $type;
 	public $args = [];
 	public $shortPath;
+	public $isVendor;
 
-	public function __construct(array $data = [], $basePath = '')
+	public function __construct(array $data = [], $basePath = '', $vendorPath = '')
 	{
 		foreach ($data as $key => $value) {
 			$this->$key = $value;
 		}
 
+		$this->call = $this->formatCall();
 		$this->shortPath = str_replace($basePath, '', $this->file);
+		$this->isVendor = strpos($this->file, $vendorPath) === 0;
+	}
+
+	protected function formatCall()
+	{
+		if ($this->class) {
+			return "{$this->class}{$this->type}{$this->function}()";
+		} else {
+			return "{$this->function}()";
+		}
 	}
 }

--- a/Clockwork/Request/Log.php
+++ b/Clockwork/Request/Log.php
@@ -16,8 +16,12 @@ class Log extends AbstractLogger
 	 */
 	public $data = [];
 
+	// Whether the log messages should have stack traces
+	protected $collectStackTraces;
+
 	/**
-	 * Add a new timestamped message, with an optional level
+	 * Add a new timestamped message, with a level and context,
+	 * $context['trace'] = true can be used to force collecting a stack trace
 	 */
 	public function log($level = LogLevel::INFO, $message, array $context = [])
 	{
@@ -31,7 +35,8 @@ class Log extends AbstractLogger
 			'time'    => microtime(true),
 			'file'    => $caller->shortPath,
 			'line'    => $caller->line,
-			'trace'   => Serializer::trace($trace->framesBefore($caller))
+			'trace'   => $this->collectStackTraces || ! empty($context['trace'])
+				? Serializer::trace($trace->framesBefore($caller)) : null
 		];
 	}
 
@@ -41,5 +46,11 @@ class Log extends AbstractLogger
 	public function toArray()
 	{
 		return $this->data;
+	}
+
+	// Enable or disable collecting of stack traces
+	public function collectStackTraces($enable = true)
+	{
+		$this->collectStackTraces = $enable;
 	}
 }

--- a/Clockwork/Request/Log.php
+++ b/Clockwork/Request/Log.php
@@ -21,7 +21,8 @@ class Log extends AbstractLogger
 	 */
 	public function log($level = LogLevel::INFO, $message, array $context = [])
 	{
-		$caller = StackTrace::get()->firstNonVendor([ 'itsgoingd', 'laravel', 'slim', 'monolog' ]);
+		$trace = StackTrace::get();
+		$caller = $trace->firstNonVendor([ 'itsgoingd', 'laravel', 'slim', 'monolog' ]);
 
 		$this->data[] = [
 			'message' => Serializer::simplify($message, 3, [ 'toString' => true ]),
@@ -29,7 +30,8 @@ class Log extends AbstractLogger
 			'level'   => $level,
 			'time'    => microtime(true),
 			'file'    => $caller->shortPath,
-			'line'    => $caller->line
+			'line'    => $caller->line,
+			'trace'   => Serializer::trace($trace->framesBefore($caller))
 		];
 	}
 

--- a/Clockwork/Storage/SqlStorage.php
+++ b/Clockwork/Storage/SqlStorage.php
@@ -168,7 +168,7 @@ class SqlStorage extends Storage
 				$this->quote('routes') . " {$textType} NULL, " .
 				$this->quote('emailsData') . " {$textType} NULL, " .
 				$this->quote('viewsData') . " {$textType} NULL, " .
-				$this->quote('userData') . " {$textType} NULL" .
+				$this->quote('userData') . " {$textType} NULL, " .
 				$this->quote('subrequests') . " {$textType} NULL" .
 			');'
 		);

--- a/Clockwork/Support/Laravel/config/clockwork.php
+++ b/Clockwork/Support/Laravel/config/clockwork.php
@@ -112,6 +112,23 @@ return [
 
 	/*
 	|--------------------------------------------------------------------------
+	| Enable collecting of stack traces
+	|--------------------------------------------------------------------------
+	|
+	| This setting controls, whether log messages and certain data sources, like
+	/ the database or cache data sources, should collect stack traces.
+	/ You might want to disable this if you are collecting 100s of queries or
+	/ log messages, as the stack traces can considerably increase the metadata size.
+	/ You can force collecting of stack trace for a single log call by passing
+	/ [ 'trace' => true ] as $context.
+	| Default: true
+	|
+	*/
+
+	'collect_stack_traces' => env('CLOCKWORK_COLLECT_STACK_TRACES', true),
+
+	/*
+	|--------------------------------------------------------------------------
 	| Ignored events
 	|--------------------------------------------------------------------------
 	|


### PR DESCRIPTION
- added support for collecting of stack trace for log messages, database, cache queries and events
- can be disabled via config (as it can considerably increase the size of collected metadata)
- can explicitly collect stack trace for a log message by passing `[ 'trace' => true ]` as `$context`
- enabled by default (for now)
- chrome PR - https://github.com/itsgoingd/clockwork-chrome/pull/53