### PR TITLE
Authentication support

### DIFF
--- a/Clockwork/Authentication/AuthenticatorInterface.php
+++ b/Clockwork/Authentication/AuthenticatorInterface.php
@@ -1,0 +1,13 @@
+<?php namespace Clockwork\Authentication;
+
+interface AuthenticatorInterface
+{
+	const REQUIRES_USERNAME = 'username';
+	const REQUIRES_PASSWORD = 'password';
+
+	public function attempt(array $credentials);
+
+	public function check($token);
+
+	public function requires();
+}

--- a/Clockwork/Authentication/NullAuthenticator.php
+++ b/Clockwork/Authentication/NullAuthenticator.php
@@ -1,0 +1,19 @@
+<?php namespace Clockwork\Authentication;
+
+class NullAuthenticator implements AuthenticatorInterface
+{
+	public function attempt(array $credentials)
+	{
+		return true;
+	}
+
+	public function check($token)
+	{
+		return true;
+	}
+
+	public function requires()
+	{
+		return [];
+	}
+}

--- a/Clockwork/Authentication/SimpleAuthenticator.php
+++ b/Clockwork/Authentication/SimpleAuthenticator.php
@@ -1,0 +1,34 @@
+<?php namespace Clockwork\Authentication;
+
+class SimpleAuthenticator implements AuthenticatorInterface
+{
+	protected $password;
+
+	public function __construct($password)
+	{
+		$this->password = $password;
+	}
+
+	public function attempt(array $credentials)
+	{
+		if (! isset($credentials['password'])) {
+			return false;
+		}
+
+		if (! hash_equals($credentials['password'], $this->password)) {
+			return false;
+		}
+
+		return password_hash($this->password, \PASSWORD_DEFAULT);
+	}
+
+	public function check($token)
+	{
+		return password_verify($this->password, $token);
+	}
+
+	public function requires()
+	{
+		return [ AuthenticatorInterface::REQUIRES_PASSWORD ];
+	}
+}

--- a/Clockwork/Clockwork.php
+++ b/Clockwork/Clockwork.php
@@ -1,6 +1,7 @@
 <?php namespace Clockwork;
 
 use Clockwork\Authentication\AuthenticatorInterface;
+use Clockwork\Authentication\NullAuthenticator;
 use Clockwork\DataSource\DataSourceInterface;
 use Clockwork\Request\Log;
 use Clockwork\Request\Request;
@@ -53,9 +54,10 @@ class Clockwork implements LoggerInterface
 	 */
 	public function __construct()
 	{
-		$this->request = new Request();
-		$this->log = new Log();
-		$this->timeline = new Timeline();
+		$this->request = new Request;
+		$this->log = new Log;
+		$this->timeline = new Timeline;
+		$this->authenticator = new NullAuthenticator;
 	}
 
 	/**

--- a/Clockwork/Clockwork.php
+++ b/Clockwork/Clockwork.php
@@ -1,5 +1,6 @@
 <?php namespace Clockwork;
 
+use Clockwork\Authentication\AuthenticatorInterface;
 use Clockwork\DataSource\DataSourceInterface;
 use Clockwork\Request\Log;
 use Clockwork\Request\Request;
@@ -33,6 +34,9 @@ class Clockwork implements LoggerInterface
 	 * Storage object, provides implementation for storing and retrieving request objects
 	 */
 	protected $storage;
+
+	// Authenticator implementation, authenticates requests for clockwork metadata
+	protected $authenticator;
 
 	/**
 	 * Request\Log instance, data structure which stores data for the log view
@@ -138,6 +142,24 @@ class Clockwork implements LoggerInterface
 	public function setStorage(StorageInterface $storage)
 	{
 		$this->storage = $storage;
+
+		return $this;
+	}
+
+	/**
+	 * Return the authenticator object
+	 */
+	public function getAuthenticator()
+	{
+		return $this->authenticator;
+	}
+
+	/**
+	 * Set a custom authenticator object
+	 */
+	public function setAuthenticator(AuthenticatorInterface $authenticator)
+	{
+		$this->authenticator = $authenticator;
 
 		return $this;
 	}

--- a/Clockwork/Support/Laravel/ClockworkController.php
+++ b/Clockwork/Support/Laravel/ClockworkController.php
@@ -16,7 +16,7 @@ class ClockworkController extends Controller
 
 	public function authenticate()
 	{
-		$token = $this->app['clockwork.authenticator']->attempt(
+		$token = $this->app['clockwork']->getAuthenticator()->attempt(
 			$this->app['request']->only([ 'username', 'password' ])
 		);
 

--- a/Clockwork/Support/Laravel/ClockworkController.php
+++ b/Clockwork/Support/Laravel/ClockworkController.php
@@ -1,6 +1,7 @@
 <?php namespace Clockwork\Support\Laravel;
 
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Controller;
 
@@ -11,6 +12,15 @@ class ClockworkController extends Controller
 	public function __construct(Application $app)
 	{
 		$this->app = $app;
+	}
+
+	public function authenticate()
+	{
+		$token = $this->app['clockwork.authenticator']->attempt(
+			$this->app['request']->only([ 'username', 'password' ])
+		);
+
+		return new JsonResponse([ 'token' => $token ], $token ? 200 : 403);
 	}
 
 	public function getData($id = null, $direction = null, $count = null)

--- a/Clockwork/Support/Laravel/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Laravel/ClockworkServiceProvider.php
@@ -1,6 +1,7 @@
 <?php namespace Clockwork\Support\Laravel;
 
 use Clockwork\Clockwork;
+use Clockwork\Authentication\AuthenticatorInterface;
 use Clockwork\DataSource\PhpDataSource;
 use Clockwork\DataSource\LaravelDataSource;
 use Clockwork\DataSource\LaravelCacheDataSource;
@@ -56,6 +57,10 @@ class ClockworkServiceProvider extends ServiceProvider
 			return new ClockworkSupport($app);
 		});
 
+		$this->app->singleton('clockwork.authenticator', function ($app) {
+			return $app['clockwork.support']->getAuthenticator();
+		});
+
 		$this->app->singleton('clockwork.laravel', function ($app) {
 			return new LaravelDataSource($app);
 		});
@@ -106,6 +111,7 @@ class ClockworkServiceProvider extends ServiceProvider
 			}
 
 			$clockwork->setStorage($support->getStorage());
+			$clockwork->setAuthenticator($app['clockwork.authenticator']);
 
 			return $clockwork;
 		});
@@ -114,6 +120,7 @@ class ClockworkServiceProvider extends ServiceProvider
 
 		// set up aliases for all Clockwork parts so they can be resolved by the IoC container
 		$this->app->alias('clockwork.support', ClockworkSupport::class);
+		$this->app->alias('clockwork.authenticator', AuthenticatorInterface::class);
 		$this->app->alias('clockwork.laravel', LaravelDataSource::class);
 		$this->app->alias('clockwork.swift', SwiftDataSource::class);
 		$this->app->alias('clockwork.eloquent', EloquentDataSource::class);
@@ -153,6 +160,7 @@ class ClockworkServiceProvider extends ServiceProvider
 		$this->app['router']->get('/__clockwork', 'Clockwork\Support\Laravel\ClockworkController@webRedirect');
 		$this->app['router']->get('/__clockwork/app', 'Clockwork\Support\Laravel\ClockworkController@webIndex');
 		$this->app['router']->get('/__clockwork/assets/{path}', 'Clockwork\Support\Laravel\ClockworkController@webAsset')->where('path', '.+');
+		$this->app['router']->post('/__clockwork/auth', 'Clockwork\Support\Laravel\ClockworkController@authenticate');
 	}
 
 	public function provides()

--- a/Clockwork/Support/Laravel/ClockworkSupport.php
+++ b/Clockwork/Support/Laravel/ClockworkSupport.php
@@ -1,6 +1,8 @@
 <?php namespace Clockwork\Support\Laravel;
 
 use Clockwork\Clockwork;
+use Clockwork\Authentication\NullAuthenticator;
+use Clockwork\Authentication\SimpleAuthenticator;
 use Clockwork\Helpers\ServerTiming;
 use Clockwork\Storage\FileStorage;
 use Clockwork\Storage\SqlStorage;
@@ -29,7 +31,14 @@ class ClockworkSupport
 	{
 		$this->app['session.store']->reflash();
 
+		$authenticator = $this->app['clockwork']->getAuthenticator();
 		$storage = $this->app['clockwork']->getStorage();
+
+		$authenticated = $authenticator->check($this->app['request']->header('X-Clockwork-Auth'));
+
+		if ($authenticated !== true) {
+			return new JsonResponse([ 'message' => $authenticated, 'requires' => $authenticator->requires() ], 403);
+		}
 
 		if ($direction == 'previous') {
 			$data = $storage->previous($id, $count);
@@ -68,6 +77,19 @@ class ClockworkSupport
 		$storage->filter = $this->getFilter();
 
 		return $storage;
+	}
+
+	public function getAuthenticator()
+	{
+		$authenticator = $this->getConfig('authentication');
+
+		if (is_string($authenticator)) {
+			return $this->app->make($authenticator);
+		} elseif ($authenticator) {
+			return new SimpleAuthenticator($this->getConfig('authentication_password'));
+		} else {
+			return new NullAuthenticator;
+		}
 	}
 
 	public function getFilter()

--- a/Clockwork/Support/Laravel/config/clockwork.php
+++ b/Clockwork/Support/Laravel/config/clockwork.php
@@ -82,6 +82,25 @@ return [
 
 	/*
 	|--------------------------------------------------------------------------
+	| Authentication
+	|--------------------------------------------------------------------------
+	|
+	| Clockwork can be configured to require authentication before allowing
+	/ access to the collected data. This is recommended when the application
+	/ is publicly accessible, as the metadata might contain sensitive information.
+	/ Setting to "true" enables authentication with a single password set below,
+	/ "false" disables authentication.
+	/ You can also pass a class name of a custom authentication implementation.
+	/ Default: false
+	|
+	*/
+
+	'authentication' => env('CLOCKWORK_AUTHENTICATION', false),
+
+	'authentication_password' => env('CLOCKWORK_AUTHENTICATION_PASSWORD', 'VerySecretPassword'),
+
+	/*
+	|--------------------------------------------------------------------------
 	| Filter collected data
 	|--------------------------------------------------------------------------
 	|

--- a/Clockwork/Support/Lumen/Controller.php
+++ b/Clockwork/Support/Lumen/Controller.php
@@ -1,17 +1,31 @@
 <?php namespace Clockwork\Support\Lumen;
 
+use Clockwork\Clockwork;
 use Clockwork\Support\Lumen\ClockworkSupport;
 
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Laravel\Lumen\Routing\Controller as LumenController;
 
 class Controller extends LumenController
 {
+	public $clockwork;
 	public $clockworkSupport;
 
-	public function __construct(ClockworkSupport $clockworkSupport)
+	public function __construct(Clockwork $clockwork, ClockworkSupport $clockworkSupport)
 	{
+		$this->clockwork = $clockwork;
 		$this->clockworkSupport = $clockworkSupport;
+	}
+
+	public function authenticate(Request $request)
+	{
+		$token = $this->clockwork->getAuthenticator()->attempt(
+			$request->only([ 'username', 'password' ])
+		);
+
+		return new JsonResponse([ 'token' => $token ], $token ? 200 : 403);
 	}
 
 	public function getData($id = null, $direction = null, $count = null)

--- a/Clockwork/Support/Slim/ClockworkMiddleware.php
+++ b/Clockwork/Support/Slim/ClockworkMiddleware.php
@@ -1,6 +1,7 @@
 <?php namespace Clockwork\Support\Slim;
 
 use Clockwork\Clockwork;
+use Clockwork\Authentication\NullAuthenticator;
 use Clockwork\DataSource\PsrMessageDataSource;
 use Clockwork\Storage\FileStorage;
 use Clockwork\Helpers\ServerTiming;
@@ -10,37 +11,58 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 
 class ClockworkMiddleware
 {
-    protected $clockwork;
-    protected $startTime;
+	protected $clockwork;
+	protected $startTime;
 
 	public function __construct($storagePathOrClockwork, $startTime = null)
 	{
 		$this->clockwork = $storagePathOrClockwork instanceof Clockwork
-            ? $storagePathOrClockwork : $this->createDefaultClockwork($storagePathOrClockwork);
+			? $storagePathOrClockwork : $this->createDefaultClockwork($storagePathOrClockwork);
 		$this->startTime = $startTime ?: microtime(true);
 	}
 
-    public function __invoke(Request $request, Response $response, callable $next)
-    {
-        return $this->process($request, $response, $next);
-    }
+	public function __invoke(Request $request, Response $response, callable $next)
+	{
+		return $this->process($request, $response, $next);
+	}
 
-    public function process(Request $request, Response $response, callable $next)
-    {
-        $clockworkDataUri = '#/__clockwork(?:/(?<id>[0-9-]+))?(?:/(?<direction>(?:previous|next)))?(?:/(?<count>\d+))?#';
-		if (preg_match($clockworkDataUri, $request->getUri()->getPath(), $matches)) {
-            $matches = array_merge([ 'direction' => null, 'count' => null ], $matches);
-			return $this->retrieveRequest($response, $matches['id'], $matches['direction'], $matches['count']);
+	public function process(Request $request, Response $response, callable $next)
+	{
+		$authUri = '#/__clockwork/auth#';
+		if (preg_match($authUri, $request->getUri()->getPath(), $matches)) {
+			return $this->authenticate($response, $request);
 		}
 
-        $response = $next($request, $response);
+		$clockworkDataUri = '#/__clockwork(?:/(?<id>[0-9-]+))?(?:/(?<direction>(?:previous|next)))?(?:/(?<count>\d+))?#';
+		if (preg_match($clockworkDataUri, $request->getUri()->getPath(), $matches)) {
+			$matches = array_merge([ 'id' => null, 'direction' => null, 'count' => null ], $matches);
+			return $this->retrieveRequest($response, $request, $matches['id'], $matches['direction'], $matches['count']);
+		}
 
-        return $this->logRequest($request, $response);
-    }
+		$response = $next($request, $response);
 
-    protected function retrieveRequest(Response $response, $id, $direction, $count)
-    {
-    	$storage = $this->clockwork->getStorage();
+		return $this->logRequest($request, $response);
+	}
+
+	protected function authenticate(Response $response, Request $request)
+	{
+		$token = $this->clockwork->getAuthenticator()->attempt($request->getParsedBody());
+
+		return $response->withJson([ 'token' => $token ])->withStatus($token ? 200 : 403);
+	}
+
+	protected function retrieveRequest(Response $response, Request $request, $id, $direction, $count)
+	{
+		$authenticator = $this->clockwork->getAuthenticator();
+		$storage = $this->clockwork->getStorage();
+
+		$authenticated = $authenticator->check(current($request->getHeader('X-Clockwork-Auth')));
+
+		if ($authenticated !== true) {
+			return $response
+				->withJson([ 'message' => $authenticated, 'requires' => $authenticator->requires() ])
+				->withStatus(403);
+		}
 
 		if ($direction == 'previous') {
 			$data = $storage->previous($id, $count);
@@ -53,37 +75,38 @@ class ClockworkMiddleware
 		}
 
 		return $response
-		    ->withHeader('Content-Type', 'application/json')
-		    ->withJson($data);
-    }
+			->withHeader('Content-Type', 'application/json')
+			->withJson($data);
+	}
 
-    protected function logRequest(Request $request, Response $response)
-    {
-    	$this->clockwork->getTimeline()->finalize($this->startTime);
-    	$this->clockwork->addDataSource(new PsrMessageDataSource($request, $response));
+	protected function logRequest(Request $request, Response $response)
+	{
+		$this->clockwork->getTimeline()->finalize($this->startTime);
+		$this->clockwork->addDataSource(new PsrMessageDataSource($request, $response));
 
-    	$this->clockwork->resolveRequest();
-    	$this->clockwork->storeRequest();
+		$this->clockwork->resolveRequest();
+		$this->clockwork->storeRequest();
 
-    	$clockworkRequest = $this->clockwork->getRequest();
+		$clockworkRequest = $this->clockwork->getRequest();
 
-    	$response = $response
-            ->withHeader('X-Clockwork-Id', $clockworkRequest->id)
+		$response = $response
+			->withHeader('X-Clockwork-Id', $clockworkRequest->id)
 			->withHeader('X-Clockwork-Version', Clockwork::VERSION);
 
-        if ($basePath = $request->getUri()->getBasePath()) {
-            $response = $response->withHeader('X-Clockwork-Path', $basePath);
-        }
+		if ($basePath = $request->getUri()->getBasePath()) {
+			$response = $response->withHeader('X-Clockwork-Path', $basePath);
+		}
 
-	    return $response->withHeader('Server-Timing', ServerTiming::fromRequest($clockworkRequest)->value());
-    }
+		return $response->withHeader('Server-Timing', ServerTiming::fromRequest($clockworkRequest)->value());
+	}
 
-    protected function createDefaultClockwork($storagePath)
-    {
-        $clockwork = new Clockwork();
+	protected function createDefaultClockwork($storagePath)
+	{
+		$clockwork = new Clockwork();
 
-        $clockwork->setStorage(new FileStorage($storagePath));
+		$clockwork->setStorage(new FileStorage($storagePath));
+		$clockwork->setAuthenticator(new NullAuthenticator);
 
-        return $clockwork;
-    }
+		return $clockwork;
+	}
 }


### PR DESCRIPTION
- added support for authentication
    - Clockwork instance can now have authenticator set, defaults to `NullAuthenticator` returning successfully authenticating all requests
    - integrations should add support for new `POST __clockwork/auth` endpoint, receiving optional `username` and `password` fields, which should be passed to the `attempt` method on authenticator and return `[ 'token' => $token ]` as json on success or HTTP 403 on failure
    - metadata requests now have an `X-Clockwork-Auth` header with the current auth token, integrations should now call `check` method with this token on the authenticator before returning data and return `[ 'message' => $message, 'requires' => $requires ]` as HTTP 403 json on failure
- added new `Clockwork\Authentication\Authenticator` interface for authentication implementations
    - `attempt(array $credentials)` - authentication attempt using provided credentials, should return auth token on success, `false` on failure
    - `check($token)` - check for validity of provided auth token, should return `true` if valid, `false` or message to be shown to user on failure
    - `requires()` - returns array of required credentials, this will be `AuthenticatorInterface\REQUIRES_USERNAME`, `AuthenticatorInterface\REQUIRES_PASSWORD` or both
- added default `SimpleAuthenticator` implementation using single plaintext password
- ootb support for Laravel, Lumen and Slim - authentication can be easily enabled and password set in the config file, including support for using custom authenticator implementations
- chrome PR - https://github.com/itsgoingd/clockwork-chrome/pull/55