### PR TITLE
Get first element of event payload with reset

### DIFF
--- a/Clockwork/DataSource/EloquentDataSource.php
+++ b/Clockwork/DataSource/EloquentDataSource.php
@@ -46,7 +46,7 @@ class EloquentDataSource extends DataSource
 		if ($scope = $this->getModelResolvingScope()) {
 			$this->eventDispatcher->listen('eloquent.booted: *', function ($model, $data = null) use ($scope) {
 				if (is_string($model) && is_array($data)) { // Laravel 5.4 wildcard event
-					$model = $data[0];
+					$model = reset($data);
 				}
 
 				$model->addGlobalScope($scope);


### PR DESCRIPTION
In favour of fico7489/laravel-pivot#29. The package rewrites event payloads to use an associative array which causes an `ErrorException: Undefined offset: 0` By retrieving the first element of the `$data` event payload, both associative and indexed arrays are supported.

```
ErrorException: Undefined offset: 0
in EloquentDataSource.php (line 49)
at HandleExceptions->handleError(8, 'Undefined offset: 0', '.../vendor/itsgoingd/clockwork/Clockwork/DataSource/EloquentDataSource.php', 49, array('model' => 'eloquent.booted: App\\Media\\Models\\File', 'data' => array('model' => object(File), 'relation' => null, 'pivotIds' => array(), 'pivotIdsAttributes' => array()), 'scope' => object(ResolveModelScope)))in ErrorHandler.php (line 34)
at Raven_Breadcrumbs_ErrorHandler->handleError(8, 'Undefined offset: 0', '.../vendor/itsgoingd/clockwork/Clockwork/DataSource/EloquentDataSource.php', 49, array('model' => 'eloquent.booted: App\\Media\\Models\\File', 'data' => array('model' => object(File), 'relation' => null, 'pivotIds' => array(), 'pivotIdsAttributes' => array()), 'scope' => object(ResolveModelScope)))in EloquentDataSource.php (line 49)
at EloquentDataSource->Clockwork\DataSource\{closure}('eloquent.booted: App\\Media\\Models\\File', array('model' => object(File), 'relation' => null, 'pivotIds' => array(), 'pivotIdsAttributes' => array()))in Dispatcher.php (line 347)
at Dispatcher->Illuminate\Events\{closure}('eloquent.booted: App\\Media\\Models\\File', array('model' => object(File), 'relation' => null, 'pivotIds' => array(), 'pivotIdsAttributes' => array()))in Dispatcher.php (line 200)
at Dispatcher->dispatch('eloquent.booted: App\\Media\\Models\\File', array('model' => object(File), 'relation' => null, 'pivotIds' => array(), 'pivotIdsAttributes' => array()), false)in Dispatcher.php (line 173)
at Dispatcher->fire('eloquent.booted: App\\Media\\Models\\File', array('model' => object(File), 'relation' => null, 'pivotIds' => array(), 'pivotIdsAttributes' => array()))in ExtendFireModelEventTrait.php (line 36)
...
(20 additional frame(s) were not displayed)
```