### PR TITLE
varchar(250) is too short because some uri is to be longer

### DIFF
--- a/Clockwork/Storage/SqlStorage.php
+++ b/Clockwork/Storage/SqlStorage.php
@@ -144,7 +144,7 @@ class SqlStorage extends Storage
 				$this->quote('version') . ' INTEGER, ' .
 				$this->quote('time') . ' DOUBLE PRECISION NULL, ' .
 				$this->quote('method') . ' VARCHAR(10) NULL, ' .
-				$this->quote('uri') . ' VARCHAR(250) NULL, ' .
+				$this->quote('uri') . " {$textType} NULL, " .
 				$this->quote('headers') . " {$textType} NULL, " .
 				$this->quote('controller') . ' VARCHAR(250) NULL, ' .
 				$this->quote('getData') . " {$textType} NULL, " .


### PR DESCRIPTION
Some uri length will be more than 250. When uri length is more than 250, insert query fail then occur PDOException.
(SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'uri' at row 1)

When PDOException occured, next run initialize(), to create Database, then error occured again
(PDOException: SQLSTATE[42S01]: Base table or view already exists: 1050 Table 'clockwork' already exists in /*****/vendor/itsgoingd/clockwork/Clockwork/Storage/SqlStorage.php:172)

This error is not inside a try/catch block, so process will fail.

I want to fix this problem. Please confirm this PR.