### PR TITLE
Added support for user-data (custom tabs in the official app)

### DIFF
--- a/Clockwork/Clockwork.php
+++ b/Clockwork/Clockwork.php
@@ -273,4 +273,10 @@ class Clockwork implements LoggerInterface
 	{
 		return $this->getRequest()->addSubrequest($url, $id, $path);
 	}
+
+	// Add custom user data (presented as additional tabs in the official app)
+	public function userData($key = null)
+	{
+		return $this->getRequest()->userData($key);
+	}
 }

--- a/Clockwork/Request/Request.php
+++ b/Clockwork/Request/Request.php
@@ -243,13 +243,15 @@ class Request
 	}
 
 	// Add custom user data (presented as additional tabs in the official app)
-	public function addUserData($key = null)
+	public function userData($key = null)
 	{
-		if ($key) {
-			return $this->userData[$key] = new UserData;
+		if ($key && isset($this->userData[$key])) {
+			return $this->userData[$key];
 		}
 
-		return $this->userData[] = new UserData;
+		$userData = (new UserData)->title($key);
+
+		return $key ? $this->userData[$key] = $userData : $this->userData[] = $userData;
 	}
 
 	/**

--- a/Clockwork/Request/Request.php
+++ b/Clockwork/Request/Request.php
@@ -143,7 +143,7 @@ class Request
 	/**
 	 * Custom user data (not used by Clockwork app)
 	 */
-	public $userData;
+	public $userData = [];
 
 	public $subrequests = [];
 
@@ -215,7 +215,9 @@ class Request
 			'routes'           => $this->routes,
 			'emailsData'       => $this->emailsData,
 			'viewsData'        => $this->viewsData,
-			'userData'         => $this->userData,
+			'userData'         => array_map(function ($data) {
+				return $data instanceof UserData ? $data->toArray() : $data;
+			}, $this->userData),
 			'subrequests'      => $this->subrequests
 		];
 	}
@@ -238,6 +240,16 @@ class Request
 			'id'   => $id,
 			'path' => $path
 		];
+	}
+
+	// Add custom user data (presented as additional tabs in the official app)
+	public function addUserData($key = null)
+	{
+		if ($key) {
+			return $this->userData[$key] = new UserData;
+		}
+
+		return $this->userData[] = new UserData;
 	}
 
 	/**

--- a/Clockwork/Request/UserData.php
+++ b/Clockwork/Request/UserData.php
@@ -1,0 +1,52 @@
+<?php namespace Clockwork\Request;
+
+// Data structure representing custom user data (shown as extra tab in the official app)
+class UserData
+{
+	// Data items (tab contents in the official app)
+	protected $data = [];
+
+	// Data title (tab name in the official app)
+	protected $title;
+
+	// Add generic user data
+	public function data(array $data, $key = null)
+	{
+		if ($key !== null) {
+			return $this->data[$key] = new UserDataItem($data);
+		}
+
+		return $this->data[] = new UserDataItem($data);
+	}
+
+	// Add user data shown as counters in the official app
+	public function counters(array $data)
+	{
+		return $this->data($data)
+			->showAs('counters');
+	}
+
+	// Add user data shown as table in the official app
+	public function table($title, array $data)
+	{
+		return $this->data($data)
+			->showAs('table')
+			->title($title);
+	}
+
+	// Set data title (shown as tab name in the official app)
+	public function title($title)
+	{
+		$this->title = $title;
+		return $this;
+	}
+
+	// Transform data and all contents to a serializable array with metadata
+	public function toArray()
+	{
+		return array_merge(
+			array_map(function ($data) { return $data->toArray(); }, $this->data),
+			[ '__meta' => array_filter([ 'title' => $this->title ]) ]
+		);
+	}
+}

--- a/Clockwork/Request/UserDataItem.php
+++ b/Clockwork/Request/UserDataItem.php
@@ -1,0 +1,55 @@
+<?php namespace Clockwork\Request;
+
+// Data structure representing custom user data item (shown as counters or table in the official app)
+class UserDataItem
+{
+	// Data contents (labels and values or table rows in the official app)
+	protected $data;
+
+	// Describes how the data should be presented ("counters" or "table" in the official app)
+	protected $showAs;
+
+	// Data title (shown as table title in the official app)
+	protected $title;
+
+	// Map of human-readable labels for the data contents
+	protected $labels;
+
+	public function __construct(array $data)
+	{
+		$this->data = $data;
+	}
+
+	// Set how the item should be presented ("counters" or "table" in the official app)
+	public function showAs($showAs)
+	{
+		$this->showAs = $showAs;
+		return $this;
+	}
+
+	// Set data title (shown as table title in the official app)
+	public function title($title)
+	{
+		$this->title = $title;
+		return $this;
+	}
+
+	// Set a map of human-readable labels for the data contents
+	public function labels($labels)
+	{
+		$this->labels = $labels;
+		return $this;
+	}
+
+	// Transform contents to a serializable array with metadata
+	public function toArray()
+	{
+		return array_merge($this->data, [
+			'__meta' => array_filter([
+				'showAs' => $this->showAs,
+				'title'  => $this->title,
+				'labels' => $this->labels
+			])
+		]);
+	}
+}


### PR DESCRIPTION
- adds support for adding custom user data (custom tabs in the official app)
- chrome PR https://github.com/itsgoingd/clockwork-chrome/pull/58

Eg.

```php
$cart = $request->addUserData('cart')
	->title('Cart');

$cart->counters([
		'products' => 3,
		'value' => '949.80€'
	])
	->labels([ 'products' => 'Products', 'value' => 'Value' ]);

$cart->table('Products', [
		[ 'product' => 'iPad Pro 10.5" 256G Silver', 'price' => '849 €' ],
		[ 'product' => 'Smart Cover iPad Pro 10.5 White', 'price' => '61.90 €' ],
		[ 'product' => 'Apple Lightning to USB 3 Camera Adapter', 'price' => '38.90 €' ]
	])
	->labels([ 'product' => 'Product', 'price' => 'Price' ]);
```