### PR TITLE
Mention auto-cleanup in config docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ You can publish the configuration file using the `vendor:publish` artisan comman
 - enable or disable the web UI
 - configure how the request metadata is stored
 - set what data should be collected
+- how long Clockwork stores log files
 
 ### Licence
 


### PR DESCRIPTION
Make sure a note is in the readme about the new (and very useful!) auto-cleaup.
See [this issue](https://github.com/itsgoingd/clockwork/issues/140)

If instead you'd like me to write a small part on the clean options in the docs, happy to help.

---
Background story: installed clockwork before and recently updated. Laravel doesn't update config automatically, so I missed the `storage_expiration`setting. Took me a while to figure out the new version had auto-cleanup I missed config for. So I hope by adding this comment others might detect it sooner.