### PR TITLE
fixes json_encode crashing php due to encoding caused by (array) casting of objects

### DIFF
--- a/Clockwork/Helpers/Serializer.php
+++ b/Clockwork/Helpers/Serializer.php
@@ -8,11 +8,17 @@ class Serializer
 		if ($data instanceof \Closure) {
 			return 'anonymous function';
 		} elseif (is_array($data)) {
-			if (! $levels) return $data;
+			$cleanData = [];
+			foreach ($data as $key => $item) {
+				$key = preg_match('/^\x00(?:.*?)\x00(.+)/', $key, $matches) ? $matches[1] : $key;
+				$cleanData[$key] = $item;
+			}
+
+			if (!$levels) return $cleanData;
 
 			return array_map(function ($item) use ($levels) {
 				return static::simplify($item, $levels - 1);
-			}, $data);
+			}, $cleanData);
 		} elseif (is_object($data)) {
 			if (isset($options['toString']) && $options['toString'] && method_exists($data, '__toString')) {
 				return (string) $data;


### PR DESCRIPTION
This shows what is happening: https://stackoverflow.com/questions/11847751/how-to-convert-cast-object-to-array-without-class-name-prefix-in-php/11847978

Basically for me when certain errors occured in my app I would get a blank response, these would be ones with public properties that would come up when casting with `(array)`, in PHP doing that uses `\x00` so when casting back it know what's what. No errors or anything so took quite some time to find.

Sometimes when `json_encode` runs it doesn't error at all, maybe just how it works on homestead and other environments the `@` you are using might fix it. Maybe this is the error for why you added `@` here? https://github.com/itsgoingd/clockwork/blob/v2/Clockwork/Storage/FileStorage.php#L87

By cleaning the `\x00` from keys in your `simplify` method the issue gets solved. 