### PR TITLE
Symfony support

### DIFF
--- a/Clockwork/Storage/SymfonyStorage.php
+++ b/Clockwork/Storage/SymfonyStorage.php
@@ -33,9 +33,9 @@ class SymfonyStorage extends FileStorage
 	// Return all ids (Symfony profiler tokens)
 	protected function ids()
 	{
-		return array_map(function ($item) {
+		return array_reverse(array_map(function ($item) {
 			return $item['token'];
-		}, $this->profiler->find(null, null, PHP_INT_MAX, null, null, null, null));
+		}, $this->profiler->find(null, null, PHP_INT_MAX, null, null, null, null)));
 	}
 
 	// Return request instances for passed tokens

--- a/Clockwork/Storage/SymfonyStorage.php
+++ b/Clockwork/Storage/SymfonyStorage.php
@@ -1,0 +1,54 @@
+<?php namespace Clockwork\Storage;
+
+use Clockwork\Request\Request;
+use Clockwork\Storage\Storage;
+use Clockwork\Support\Symfony\ProfileTransformer;
+
+use Symfony\Component\HttpKernel\Profiler\Profiler;
+
+// Storage wrapping Symfony profiler
+class SymfonyStorage extends FileStorage
+{
+	// Symfony profiler instance
+	protected $profiler;
+
+	// Create a new instance, takes Symfony profiler instance as argument
+	public function __construct(Profiler $profiler)
+	{
+		$this->profiler = $profiler;
+	}
+
+	// Store request, no-op since this is read-only storage implementation
+	public function store(Request $request)
+	{
+		return;
+	}
+
+	// Cleanup old requests, no-op since this is read-only storage implementation
+	public function cleanup($force = false)
+	{
+		return;
+	}
+
+	// Return all ids (Symfony profiler tokens)
+	protected function ids()
+	{
+		return array_map(function ($item) {
+			return $item['token'];
+		}, $this->profiler->find(null, null, PHP_INT_MAX, null, null, null, null));
+	}
+
+	// Return request instances for passed tokens
+	protected function idsToRequests($tokens)
+	{
+		return array_filter(array_map(function ($token) {
+			return $this->transformProfile($this->profiler->loadProfile($token));
+		}, $tokens));
+	}
+
+	// Transform Symfony profile instance to Clockwork request
+	public function transformProfile($profile)
+	{
+		return $profile ? (new ProfileTransformer)->transform($profile) : null;
+	}
+}

--- a/Clockwork/Support/Symfony/ClockworkBundle.php
+++ b/Clockwork/Support/Symfony/ClockworkBundle.php
@@ -1,0 +1,11 @@
+<?php namespace Clockwork\Support\Symfony;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class ClockworkBundle extends Bundle
+{
+	protected function getContainerExtensionClass()
+	{
+		return ClockworkExtension::class;
+	}
+}

--- a/Clockwork/Support/Symfony/ClockworkConfiguration.php
+++ b/Clockwork/Support/Symfony/ClockworkConfiguration.php
@@ -5,17 +5,19 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class ClockworkConfiguration implements ConfigurationInterface
 {
+	protected $debug;
+
+	public function __construct($debug)
+	{
+		$this->debug = $debug;
+	}
+
 	public function getConfigTreeBuilder()
 	{
-		$treeBuilder = new TreeBuilder();
-		$rootNode = $treeBuilder->root('clockwork');
-
-		$rootNode
+		return (new TreeBuilder)->root('clockwork')
 			->children()
-				->booleanNode('enabled')->defaultTrue()->end()
-			->end()
-		;
-
-		return $treeBuilder;
+				->booleanNode('enable')->defaultValue($this->debug)->end()
+                ->end()
+			->end();
 	}
 }

--- a/Clockwork/Support/Symfony/ClockworkConfiguration.php
+++ b/Clockwork/Support/Symfony/ClockworkConfiguration.php
@@ -1,0 +1,21 @@
+<?php namespace Clockwork\Support\Symfony;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class ClockworkConfiguration implements ConfigurationInterface
+{
+	public function getConfigTreeBuilder()
+	{
+		$treeBuilder = new TreeBuilder();
+		$rootNode = $treeBuilder->root('clockwork');
+
+		$rootNode
+			->children()
+				->booleanNode('enabled')->defaultTrue()->end()
+			->end()
+		;
+
+		return $treeBuilder;
+	}
+}

--- a/Clockwork/Support/Symfony/ClockworkConfiguration.php
+++ b/Clockwork/Support/Symfony/ClockworkConfiguration.php
@@ -19,6 +19,8 @@ class ClockworkConfiguration implements ConfigurationInterface
 				->booleanNode('enable')->defaultValue($this->debug)->end()
 				->booleanNode('web')->defaultValue(true)->end()
 				->booleanNode('web_dark_theme')->defaultValue(false)->end()
+				->booleanNode('authentication')->defaultValue(false)->end()
+				->scalarNode('authentication_password')->defaultValue('VerySecretPassword')->end()
 				->end()
 			->end();
 	}

--- a/Clockwork/Support/Symfony/ClockworkConfiguration.php
+++ b/Clockwork/Support/Symfony/ClockworkConfiguration.php
@@ -17,7 +17,9 @@ class ClockworkConfiguration implements ConfigurationInterface
 		return (new TreeBuilder)->root('clockwork')
 			->children()
 				->booleanNode('enable')->defaultValue($this->debug)->end()
-                ->end()
+				->booleanNode('web')->defaultValue(true)->end()
+				->booleanNode('web_dark_theme')->defaultValue(false)->end()
+				->end()
 			->end();
 	}
 }

--- a/Clockwork/Support/Symfony/ClockworkController.php
+++ b/Clockwork/Support/Symfony/ClockworkController.php
@@ -1,6 +1,9 @@
 <?php namespace Clockwork\Support\Symfony;
 
+use Clockwork\Clockwork;
+
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
 
@@ -9,35 +12,43 @@ class ClockworkController extends Controller
 	protected $clockwork;
 	protected $profiler;
 
-	public function __construct(ClockworkSupport $clockwork, Profiler $profiler)
+	public function __construct(Clockwork $clockwork, ClockworkSupport $support, Profiler $profiler)
 	{
 		$this->clockwork = $clockwork;
+		$this->support = $support;
 		$this->profiler = $profiler;
 	}
 
-	public function getData($id = null, $direction = null, $count = null)
+	public function authenticate(Request $request)
+	{
+		$token = $this->clockwork->getAuthenticator()->attempt($request->request->all());
+
+		return new JsonResponse([ 'token' => $token ], $token ? 200 : 403);
+	}
+
+	public function getData(Request $request, $id = null, $direction = null, $count = null)
 	{
 		$this->profiler->disable();
 
-		return $this->clockwork->getData($id, $direction, $count);
+		return $this->support->getData($request, $id, $direction, $count);
 	}
 
 	public function webIndex(Request $request)
 	{
 		$this->profiler->disable();
 
-		if ($this->clockwork->isWebUsingDarkTheme() && ! $request->query->has('dark')) {
+		if ($this->support->isWebUsingDarkTheme() && ! $request->query->has('dark')) {
 			return $this->redirect('/__clockwork/app?dark');
 		}
 
-		return $this->clockwork->getWebAsset('app.html');
+		return $this->support->getWebAsset('app.html');
 	}
 
 	public function webAsset($path)
 	{
 		$this->profiler->disable();
 
-		return $this->clockwork->getWebAsset("assets/{$path}");
+		return $this->support->getWebAsset("assets/{$path}");
 	}
 
 	public function webRedirect()

--- a/Clockwork/Support/Symfony/ClockworkController.php
+++ b/Clockwork/Support/Symfony/ClockworkController.php
@@ -1,16 +1,15 @@
 <?php namespace Clockwork\Support\Symfony;
 
-use Clockwork\Clockwork;
-
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
 
 class ClockworkController extends Controller
 {
-	private $clockwork;
-	private $profiler;
+	protected $clockwork;
+	protected $profiler;
 
-	public function __construct(Clockwork $clockwork, Profiler $profiler)
+	public function __construct(ClockworkSupport $clockwork, Profiler $profiler)
 	{
 		$this->clockwork = $clockwork;
 		$this->profiler = $profiler;
@@ -20,6 +19,31 @@ class ClockworkController extends Controller
 	{
 		$this->profiler->disable();
 
-		return $this->container->get('clockwork.support')->getData($id, $direction, $count);
+		return $this->clockwork->getData($id, $direction, $count);
+	}
+
+	public function webIndex(Request $request)
+	{
+		$this->profiler->disable();
+
+		if ($this->clockwork->isWebUsingDarkTheme() && ! $request->query->has('dark')) {
+			return $this->redirect('/__clockwork/app?dark');
+		}
+
+		return $this->clockwork->getWebAsset('app.html');
+	}
+
+	public function webAsset($path)
+	{
+		$this->profiler->disable();
+
+		return $this->clockwork->getWebAsset("assets/{$path}");
+	}
+
+	public function webRedirect()
+	{
+		$this->profiler->disable();
+
+		return $this->redirect('/__clockwork/app');
 	}
 }

--- a/Clockwork/Support/Symfony/ClockworkController.php
+++ b/Clockwork/Support/Symfony/ClockworkController.php
@@ -1,0 +1,25 @@
+<?php namespace Clockwork\Support\Symfony;
+
+use Clockwork\Clockwork;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpKernel\Profiler\Profiler;
+
+class ClockworkController extends Controller
+{
+	private $clockwork;
+	private $profiler;
+
+	public function __construct(Clockwork $clockwork, Profiler $profiler)
+	{
+		$this->clockwork = $clockwork;
+		$this->profiler = $profiler;
+	}
+
+	public function getData($id = null, $direction = null, $count = null)
+	{
+		$this->profiler->disable();
+
+		return $this->container->get('clockwork.support')->getData($id, $direction, $count);
+	}
+}

--- a/Clockwork/Support/Symfony/ClockworkExtension.php
+++ b/Clockwork/Support/Symfony/ClockworkExtension.php
@@ -1,0 +1,22 @@
+<?php namespace Clockwork\Support\Symfony;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
+
+class ClockworkExtension extends ConfigurableExtension
+{
+	public function loadInternal(array $config, ContainerBuilder $container)
+	{
+		$loader = new PhpFileLoader($container, new FileLocator(__DIR__ . '/Resources/config'));
+		$loader->load('clockwork.php');
+
+		$container->getDefinition(ClockworkSupport::class)->replaceArgument('$config', $config);
+	}
+
+	public function getConfiguration(array $config, ContainerBuilder $container)
+	{
+		return new ClockworkConfiguration;
+	}
+}

--- a/Clockwork/Support/Symfony/ClockworkExtension.php
+++ b/Clockwork/Support/Symfony/ClockworkExtension.php
@@ -17,6 +17,6 @@ class ClockworkExtension extends ConfigurableExtension
 
 	public function getConfiguration(array $config, ContainerBuilder $container)
 	{
-		return new ClockworkConfiguration;
+		return new ClockworkConfiguration($container->getParameter('kernel.debug'));
 	}
 }

--- a/Clockwork/Support/Symfony/ClockworkFactory.php
+++ b/Clockwork/Support/Symfony/ClockworkFactory.php
@@ -1,0 +1,36 @@
+<?php namespace Clockwork\Support\Symfony;
+
+use Clockwork\Clockwork;
+use Clockwork\Storage\SymfonyStorage;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class ClockworkFactory
+{
+	public function __construct(ContainerInterface $container)
+	{
+		$this->container = $container;
+	}
+
+	public function clockwork()
+	{
+		return (new Clockwork)
+			->setAuthenticator($this->container->get('clockwork.authenticator'))
+			->setStorage($this->container->get('clockwork.storage'));
+	}
+
+	public function clockworkAuthenticator()
+	{
+		return $this->container->get('clockwork.support')->getAuthenticator();
+	}
+
+	public function clockworkStorage()
+	{
+		return new SymfonyStorage($this->container->get('profiler'));
+	}
+
+	public function clockworkSupport($config)
+	{
+		return new ClockworkSupport($this->container, $config);
+	}
+}

--- a/Clockwork/Support/Symfony/ClockworkListener.php
+++ b/Clockwork/Support/Symfony/ClockworkListener.php
@@ -1,0 +1,28 @@
+<?php namespace Clockwork\Support\Symfony;
+
+use Clockwork\Clockwork;
+
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class ClockworkListener implements EventSubscriberInterface
+{
+	public function onKernelResponse(FilterResponseEvent $event)
+	{
+		$response = $event->getResponse();
+		$request = $event->getRequest();
+
+		if ($response->headers->has('X-Debug-Token')) {
+			$response->headers->set('X-Clockwork-Id', $response->headers->get('X-Debug-Token'));
+			$response->headers->set('X-Clockwork-Version', Clockwork::VERSION);
+		}
+	}
+
+	public static function getSubscribedEvents()
+	{
+		return [
+			KernelEvents::RESPONSE => [ 'onKernelResponse', -128 ],
+		];
+	}
+}

--- a/Clockwork/Support/Symfony/ClockworkListener.php
+++ b/Clockwork/Support/Symfony/ClockworkListener.php
@@ -8,15 +8,23 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class ClockworkListener implements EventSubscriberInterface
 {
+	protected $clockwork;
+
+	public function __construct(ClockworkSupport $clockwork)
+	{
+		$this->clockwork = $clockwork;
+	}
+
 	public function onKernelResponse(FilterResponseEvent $event)
 	{
-		$response = $event->getResponse();
-		$request = $event->getRequest();
+		if (! $this->clockwork->isEnabled()) return;
 
-		if ($response->headers->has('X-Debug-Token')) {
-			$response->headers->set('X-Clockwork-Id', $response->headers->get('X-Debug-Token'));
-			$response->headers->set('X-Clockwork-Version', Clockwork::VERSION);
-		}
+		$response = $event->getResponse();
+
+		if (! $response->headers->has('X-Debug-Token')) return;
+
+		$response->headers->set('X-Clockwork-Id', $response->headers->get('X-Debug-Token'));
+		$response->headers->set('X-Clockwork-Version', Clockwork::VERSION);
 	}
 
 	public static function getSubscribedEvents()

--- a/Clockwork/Support/Symfony/ClockworkSupport.php
+++ b/Clockwork/Support/Symfony/ClockworkSupport.php
@@ -39,4 +39,9 @@ class ClockworkSupport
 
 		return new JsonResponse($data);
 	}
+
+	public function isEnabled()
+	{
+		return $this->getConfig('enable', false);
+	}
 }

--- a/Clockwork/Support/Symfony/ClockworkSupport.php
+++ b/Clockwork/Support/Symfony/ClockworkSupport.php
@@ -1,7 +1,11 @@
 <?php namespace Clockwork\Support\Symfony;
 
+use Clockwork\Web\Web;
+
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class ClockworkSupport
 {
@@ -34,14 +38,30 @@ class ClockworkSupport
 		}
 
 		$data = is_array($data)
-			? array_map(function ($request) { return $request->toArray(); }, $request)
+			? array_map(function ($request) { return $request->toArray(); }, $data)
 			: $data->toArray();
 
 		return new JsonResponse($data);
 	}
 
+	public function getWebAsset($path)
+	{
+		$web = new Web;
+
+		if ($asset = $web->asset($path)) {
+			return new BinaryFileResponse($asset['path'], 200, [ 'Content-Type' => $asset['mime'] ]);
+		} else {
+			throw new NotFoundHttpException;
+		}
+	}
+
 	public function isEnabled()
 	{
 		return $this->getConfig('enable', false);
+	}
+
+	public function isWebUsingDarkTheme()
+	{
+		return $this->getConfig('web_dark_theme', false);
 	}
 }

--- a/Clockwork/Support/Symfony/ClockworkSupport.php
+++ b/Clockwork/Support/Symfony/ClockworkSupport.php
@@ -1,0 +1,42 @@
+<?php namespace Clockwork\Support\Symfony;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class ClockworkSupport
+{
+	protected $container;
+	protected $config;
+
+	public function __construct(ContainerInterface $container, $config)
+	{
+		$this->container = $container;
+		$this->config = $config;
+	}
+
+	public function getConfig($key, $default = null)
+	{
+		return isset($this->config[$key]) ? $this->config[$key] : $default;
+	}
+
+	public function getData($id = null, $direction = null, $count = null)
+	{
+		$storage = $this->container->get('clockwork')->getStorage();
+
+		if ($direction == 'previous') {
+			$data = $storage->previous($id, $count);
+		} elseif ($direction == 'next') {
+			$data = $storage->next($id, $count);
+		} elseif ($id == 'latest') {
+			$data = $storage->latest();
+		} else {
+			$data = $storage->find($id);
+		}
+
+		$data = is_array($data)
+			? array_map(function ($request) { return $request->toArray(); }, $request)
+			: $data->toArray();
+
+		return new JsonResponse($data);
+	}
+}

--- a/Clockwork/Support/Symfony/ProfileTransformer.php
+++ b/Clockwork/Support/Symfony/ProfileTransformer.php
@@ -1,0 +1,283 @@
+<?php namespace Clockwork\Support\Symfony;
+
+use Clockwork\Helpers\Serializer;
+use Clockwork\Request\Request;
+
+use Symfony\Component\HttpKernel\Profiler\Profile;
+
+class ProfileTransformer
+{
+	public function transform(Profile $profile)
+	{
+		$request = new Request;
+
+		$this->transformCacheData($profile, $request);
+		$this->transformDoctrineData($profile, $request);
+		$this->transformEventsData($profile, $request);
+		$this->transformLoggerData($profile, $request);
+		$this->transformRequestData($profile, $request);
+		$this->transformTimeData($profile, $request);
+		$this->transformTwigData($profile, $request);
+
+		$request->subrequests = $this->getSubrequests($profile);
+
+		return $request;
+	}
+
+	// Cache collector
+
+	protected function transformCacheData(Profile $profile, Request $request)
+	{
+		$data = $profile->getCollector('cache');
+
+		$request->cacheQueries = $this->getCacheQueries($data);
+		$request->cacheReads   = $data->getTotals()['reads'];
+		$request->cacheHits    = $data->getTotals()['hits'];
+		$request->cacheWrites  = $data->getTotals()['writes'];
+		$request->cacheDeletes = $data->getTotals()['deletes'];
+	}
+
+	protected function getCacheQueries($data)
+	{
+		return array_reduce(array_map(function ($queries, $connection) {
+			return array_filter(array_map(function ($query) use ($connection) {
+				$value = $query['result'];
+
+				if (! is_array($value) || ! count($value)) return;
+
+				return [
+					'connection' => $connection,
+					'time' => $query['end'] - $query['start'],
+					'type' => array_values($value)[0] ? 'hit' : 'miss',
+					'key' => array_keys($value)[0],
+					'value' => ''
+				];
+			}, $queries));
+		}, $this->unwrap($data->getCalls()), array_keys($this->unwrap($data->getCalls()))), function ($all, $queries) {
+			return array_merge($all, $queries);
+		}, []);
+	}
+
+	// Doctrine collector
+
+	protected function transformDoctrineData(Profile $profile, Request $request)
+	{
+		$data = $profile->getCollector('db');
+
+		$request->databaseDuration = $data->getTime();
+		$request->databaseQueries = $this->getQueries($data);
+	}
+
+	protected function getQueries($data)
+	{
+		return array_reduce(array_map(function ($queries, $connection) {
+			return array_filter(array_map(function ($query) use ($connection) {
+				return [
+					'query'      => $this->createRunnableQuery($query['sql'], $this->unwrap($query['params'])),
+					'duration'   => $query['executionMS'] * 1000,
+					'connection' => $connection
+				];
+			}, $queries));
+		}, $data->getQueries(), array_keys($data->getQueries())), function ($all, $queries) {
+			return array_merge($all, $queries);
+		}, []);
+	}
+
+	protected function createRunnableQuery($query, $bindings)
+	{
+		foreach ($bindings as $binding) {
+			$binding = \Doctrine\Bundle\DoctrineBundle\Twig\DoctrineExtension::escapeFunction($binding);
+
+			// escape backslashes in the binding (preg_replace requires to do so)
+			$binding = str_replace('\\', '\\\\', $binding);
+
+			$query = preg_replace('/\?/', $binding, $query, 1);
+		}
+
+		// highlight keywords
+		$keywords = [
+			'select', 'insert', 'update', 'delete', 'where', 'from', 'limit', 'is', 'null', 'having', 'group by',
+			'order by', 'asc', 'desc'
+		];
+		$regexp = '/\b' . implode('\b|\b', $keywords) . '\b/i';
+
+		$query = preg_replace_callback($regexp, function ($match) { return strtoupper($match[0]); }, $query);
+
+		return $query;
+	}
+
+	// Events collector
+
+	protected function transformEventsData(Profile $profile, Request $request)
+	{
+		$data = $profile->getCollector('events');
+
+		$request->events = $this->getEvents($data);
+	}
+
+	protected function getEvents($data)
+	{
+		$handledEvents = array_values(array_reduce($this->unwrap($data->getCalledListeners()), function ($events, $listener) {
+			if (! isset($events[$listener['event']])) {
+				$events[$listener['event']] = [ 'event' => $listener['event'], 'listeners' => [] ];
+			}
+
+			$events[$listener['event']]['listeners'][] = $listener['stub'];
+
+			return $events;
+		}, []));
+
+		$orphanedEvents = array_map(function ($event) {
+			return [ 'event' => $event ];
+		}, $this->unwrap($data->getOrphanedEvents()));
+
+		return array_merge($handledEvents, $orphanedEvents);
+	}
+
+	// Log collector
+
+	protected function transformLoggerData(Profile $profile, Request $request)
+	{
+		$data = $profile->getCollector('logger');
+
+		$request->log = $this->getLog($data);
+	}
+
+	protected function getLog($data)
+	{
+		return array_map(function ($log) {
+			$context = isset($log['context']) ? $log['context'] : [];
+			$replacements = array_filter($context, function ($v) { return ! is_array($v) && ! is_object($v) && ! is_resource($v); });
+
+			return [
+				'message' => str_replace(
+					array_map(function ($v) { return "{{$v}}"; }, array_keys($replacements)),
+					array_values($replacements),
+					$log['message']
+				),
+				'context' => Serializer::simplify($log['context']),
+				'level'   => strtolower($log['priorityName']),
+				'time'    => $log['timestamp']
+			];
+		}, $this->unwrap($data->getLogs()));
+	}
+
+	// Request collector
+
+	protected function transformRequestData(Profile $profile, Request $request)
+	{
+		$data = $profile->getCollector('request');
+
+		$request->method         = $data->getMethod();
+		$request->uri            = $data->getPathInfo();
+		$request->controller     = $this->getController($data);
+		$request->responseStatus = $data->getStatusCode();
+		$request->headers        = $this->unwrap($data->getRequestHeaders());
+		$request->getData        = $this->unwrap($data->getRequestQuery());
+		$request->postData       = $this->unwrap($data->getRequestRequest());
+		$request->cookies        = $this->unwrap($data->getRequestCookies());
+		$request->sessionData    = Serializer::simplify($this->unwrap($data->getSessionAttributes()));
+	}
+
+	protected function getController($data)
+	{
+		$controller = $this->unwrap($data->getController());
+
+		if (! is_array($controller)) return $controller;
+
+		return isset($controller['method'])
+			? "{$controller['class']}@{$controller['method']}"
+			: $controller['class'];
+	}
+
+	// Time collector
+
+	protected function transformTimeData(Profile $profile, Request $request)
+	{
+		$data = $profile->getCollector('time');
+
+		$request->time         = $data->getStartTime() / 1000;
+		$request->responseTime = $this->getResponseTime($data);
+		$request->timelineData = $this->getTimeline($data);
+	}
+
+	protected function getResponseTime($data)
+	{
+		$lastEvent = $data->getEvents()['__section__'];
+
+		return ($lastEvent->getOrigin() + $lastEvent->getDuration()) / 1000;
+	}
+
+	protected function getTimeline($data)
+	{
+		$events = array_map(function ($event, $name) {
+			if ($name == '__section__') {
+				$name = 'Application runtime';
+			} elseif ($name == '__section__.child') {
+				$name = 'Subrequest';
+			}
+
+			return [
+				'start'       => ($event->getOrigin() + $event->getStartTime()) / 1000,
+				'end'         => ($event->getOrigin() + $event->getEndTime()) / 1000,
+				'duration'    => $event->getDuration(),
+				'description' => $name,
+				'data'        => []
+			];
+		}, $data->getEvents(), array_keys($data->getEvents()));
+
+		$topEvent = $data->getEvents()['__section__'];
+		array_unshift($events, [
+			'start'       => $start = $data->getStartTime() / 1000,
+			'end'         => $end = ($topEvent->getOrigin() + $topEvent->getStartTime()) / 1000,
+			'duration'    => ($end - $start) * 1000,
+			'description' => 'Symfony initialization',
+			'data'        => []
+		]);
+
+		return $events;
+	}
+
+	// Twig collector
+
+	protected function transformTwigData(Profile $profile, Request $request)
+	{
+		$data = $profile->getCollector('twig');
+
+		$request->viewsData = $this->getViews($data);
+	}
+
+	protected function getViews($data)
+	{
+		return array_map(function ($template) {
+			return [
+				'description' => 'Rendering a view',
+				'data' => [ 'name' => $template, 'data' => [] ]
+			];
+		}, array_keys($data->getTemplates()));
+	}
+
+	protected function getSubrequests($profile)
+	{
+		return array_map(function ($child) {
+			return [
+				'url'  => urlencode($child->getCollector('request')->getPathInfo()),
+				'id'   => $child->getToken(),
+				'path' => null
+			];
+		}, $profile->getChildren());
+	}
+
+	protected function unwrap($data)
+	{
+		if ($data instanceof \Symfony\Component\VarDumper\Cloner\Data) {
+			return $data->getValue(true);
+		} elseif ($data instanceof \Symfony\Component\HttpFoundation\ParameterBag) {
+			return array_map(function ($val) { return $val->getValue(); }, $data->all());
+		} elseif (is_array($data)) {
+			return array_map(function ($item) { return $this->unwrap($item); }, $data);
+		}
+
+		return $data;
+	}
+}

--- a/Clockwork/Support/Symfony/ProfileTransformer.php
+++ b/Clockwork/Support/Symfony/ProfileTransformer.php
@@ -9,7 +9,7 @@ class ProfileTransformer
 {
 	public function transform(Profile $profile)
 	{
-		$request = new Request;
+		$request = new Request([ 'id' => $profile->getToken() ]);
 
 		$this->transformCacheData($profile, $request);
 		$this->transformDoctrineData($profile, $request);

--- a/Clockwork/Support/Symfony/ProfileTransformer.php
+++ b/Clockwork/Support/Symfony/ProfileTransformer.php
@@ -28,6 +28,8 @@ class ProfileTransformer
 
 	protected function transformCacheData(Profile $profile, Request $request)
 	{
+		if (! $profile->hasCollector('cache')) return;
+
 		$data = $profile->getCollector('cache');
 
 		$request->cacheQueries = $this->getCacheQueries($data);
@@ -62,6 +64,8 @@ class ProfileTransformer
 
 	protected function transformDoctrineData(Profile $profile, Request $request)
 	{
+		if (! $profile->hasCollector('db')) return;
+
 		$data = $profile->getCollector('db');
 
 		$request->databaseDuration = $data->getTime();
@@ -110,6 +114,8 @@ class ProfileTransformer
 
 	protected function transformEventsData(Profile $profile, Request $request)
 	{
+		if (! $profile->hasCollector('events')) return;
+
 		$data = $profile->getCollector('events');
 
 		$request->events = $this->getEvents($data);
@@ -138,6 +144,8 @@ class ProfileTransformer
 
 	protected function transformLoggerData(Profile $profile, Request $request)
 	{
+		if (! $profile->hasCollector('logger')) return;
+
 		$data = $profile->getCollector('logger');
 
 		$request->log = $this->getLog($data);
@@ -166,6 +174,8 @@ class ProfileTransformer
 
 	protected function transformRequestData(Profile $profile, Request $request)
 	{
+		if (! $profile->hasCollector('request')) return;
+
 		$data = $profile->getCollector('request');
 
 		$request->method         = $data->getMethod();
@@ -194,6 +204,8 @@ class ProfileTransformer
 
 	protected function transformTimeData(Profile $profile, Request $request)
 	{
+		if (! $profile->hasCollector('time')) return;
+
 		$data = $profile->getCollector('time');
 
 		$request->time         = $data->getStartTime() / 1000;
@@ -242,6 +254,8 @@ class ProfileTransformer
 
 	protected function transformTwigData(Profile $profile, Request $request)
 	{
+		if (! $profile->hasCollector('twig')) return;
+
 		$data = $profile->getCollector('twig');
 
 		$request->viewsData = $this->getViews($data);

--- a/Clockwork/Support/Symfony/Resources/config/clockwork.php
+++ b/Clockwork/Support/Symfony/Resources/config/clockwork.php
@@ -11,7 +11,7 @@ $container->register(Clockwork\Support\Symfony\ClockworkSupport::class)
 	->setArgument('$config', [])
 	->setPublic(true);
 
-$container->register(Clockwork\Support\Symfony\ClockworkListener::class)
+$container->autowire(Clockwork\Support\Symfony\ClockworkListener::class)
 	->addTag('kernel.event_subscriber');
 
 $container->autowire(Clockwork\Storage\SymfonyStorage::class)

--- a/Clockwork/Support/Symfony/Resources/config/clockwork.php
+++ b/Clockwork/Support/Symfony/Resources/config/clockwork.php
@@ -1,25 +1,36 @@
 <?php
 
+use Clockwork\Support\Symfony\ClockworkFactory;
+
 use Symfony\Component\DependencyInjection\Reference;
 
+$container->autowire(Clockwork\Support\Symfony\ClockworkFactory::class);
+
 $container->register(Clockwork\Clockwork::class)
-	->addMethodCall('setStorage', [ new Reference(Clockwork\Storage\SymfonyStorage::class) ])
+	->setFactory([ new Reference(ClockworkFactory::class), 'clockwork' ])
+	->setPublic(true);
+
+$container->register(Clockwork\Authentication\AuthenticatorInterface::class)
+	->setFactory([ new Reference(ClockworkFactory::class), 'clockworkAuthenticator' ])
+	->setPublic(true);
+
+$container->register(Clockwork\Storage\StorageInterface::class)
+	->setFactory([ new Reference(ClockworkFactory::class), 'clockworkStorage' ])
 	->setPublic(true);
 
 $container->register(Clockwork\Support\Symfony\ClockworkSupport::class)
-	->setArgument('$container', new Reference('service_container'))
 	->setArgument('$config', [])
+	->setFactory([ new Reference(ClockworkFactory::class), 'clockworkSupport' ])
 	->setPublic(true);
-
-$container->autowire(Clockwork\Support\Symfony\ClockworkListener::class)
-	->addTag('kernel.event_subscriber');
-
-$container->autowire(Clockwork\Storage\SymfonyStorage::class)
-	->setArgument('$profiler', new Reference('profiler'));
 
 $container->autowire(Clockwork\Support\Symfony\ClockworkController::class)
 	->setAutoconfigured(true)
 	->setArgument('$profiler', new Reference('profiler'));
 
+$container->autowire(Clockwork\Support\Symfony\ClockworkListener::class)
+	->addTag('kernel.event_subscriber');
+
 $container->setAlias('clockwork', Clockwork\Clockwork::class)->setPublic('true');
+$container->setAlias('clockwork.authenticator', Clockwork\Authentication\AuthenticatorInterface::class)->setPublic('true');
+$container->setAlias('clockwork.storage', Clockwork\Storage\StorageInterface::class)->setPublic('true');
 $container->setAlias('clockwork.support', Clockwork\Support\Symfony\ClockworkSupport::class)->setPublic('true');

--- a/Clockwork/Support/Symfony/Resources/config/clockwork.php
+++ b/Clockwork/Support/Symfony/Resources/config/clockwork.php
@@ -1,0 +1,25 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Reference;
+
+$container->register(Clockwork\Clockwork::class)
+	->addMethodCall('setStorage', [ new Reference(Clockwork\Storage\SymfonyStorage::class) ])
+	->setPublic(true);
+
+$container->register(Clockwork\Support\Symfony\ClockworkSupport::class)
+	->setArgument('$container', new Reference('service_container'))
+	->setArgument('$config', [])
+	->setPublic(true);
+
+$container->register(Clockwork\Support\Symfony\ClockworkListener::class)
+	->addTag('kernel.event_subscriber');
+
+$container->autowire(Clockwork\Storage\SymfonyStorage::class)
+	->setArgument('$profiler', new Reference('profiler'));
+
+$container->autowire(Clockwork\Support\Symfony\ClockworkController::class)
+	->setAutoconfigured(true)
+	->setArgument('$profiler', new Reference('profiler'));
+
+$container->setAlias('clockwork', Clockwork\Clockwork::class)->setPublic('true');
+$container->setAlias('clockwork.support', Clockwork\Support\Symfony\ClockworkSupport::class)->setPublic('true');

--- a/Clockwork/Support/Symfony/Resources/config/routing/clockwork.php
+++ b/Clockwork/Support/Symfony/Resources/config/routing/clockwork.php
@@ -1,0 +1,13 @@
+<?php
+
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+$routes = new RouteCollection();
+$routes->add('clockwork', new Route('/__clockwork/{id}/{direction}/{count}', [
+	'_controller' => [ Clockwork\Support\Symfony\ClockworkController::class, 'getData' ],
+	'direction' => null,
+	'count' => null
+], [ 'id' => '([a-z0-9-]+|latest)', 'direction' => '(next|previous)', 'count' => '\d+' ]));
+
+return $routes;

--- a/Clockwork/Support/Symfony/Resources/config/routing/clockwork.php
+++ b/Clockwork/Support/Symfony/Resources/config/routing/clockwork.php
@@ -17,6 +17,10 @@ $routes->add('clockwork.webAsset', new Route('/__clockwork/assets/{path}', [
 	'_controller' => [ Clockwork\Support\Symfony\ClockworkController::class, 'webAsset' ]
 ], [ 'path' => '.+' ]));
 
+$routes->add('clockwork.auth', new Route('/__clockwork/auth', [
+	'_controller' => [ Clockwork\Support\Symfony\ClockworkController::class, 'authenticate' ]
+]));
+
 $routes->add('clockwork', new Route('/__clockwork/{id}/{direction}/{count}', [
 	'_controller' => [ Clockwork\Support\Symfony\ClockworkController::class, 'getData' ],
 	'direction' => null,

--- a/Clockwork/Support/Symfony/Resources/config/routing/clockwork.php
+++ b/Clockwork/Support/Symfony/Resources/config/routing/clockwork.php
@@ -4,6 +4,19 @@ use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
 $routes = new RouteCollection();
+
+$routes->add('clockwork.webRedirect', new Route('/__clockwork', [
+	'_controller' => [ Clockwork\Support\Symfony\ClockworkController::class, 'webRedirect' ]
+]));
+
+$routes->add('clockwork.webIndex', new Route('/__clockwork/app', [
+	'_controller' => [ Clockwork\Support\Symfony\ClockworkController::class, 'webIndex' ]
+]));
+
+$routes->add('clockwork.webAsset', new Route('/__clockwork/assets/{path}', [
+	'_controller' => [ Clockwork\Support\Symfony\ClockworkController::class, 'webAsset' ]
+], [ 'path' => '.+' ]));
+
 $routes->add('clockwork', new Route('/__clockwork/{id}/{direction}/{count}', [
 	'_controller' => [ Clockwork\Support\Symfony\ClockworkController::class, 'getData' ],
 	'direction' => null,


### PR DESCRIPTION
- initial support for Symfony 🎉 
- built on top of the Symfony profiler
- Clockwork uses profiles collected by the Symfony profiler instead of collecting the data itself (similar to the Symfony web profiler)
- supports authentication, web UI, any data collected by the Symfony profiler
- doesn't support the clock helper, logging and timeline events via Clockwork, stack traces, server-timing headers, metadata request headers, custom data sources, any data not collected by the Symfony profiler