### PR TITLE
Add support for resolving Laravel compiled view names in stack traces

### DIFF
--- a/Clockwork/DataSource/EloquentDataSource.php
+++ b/Clockwork/DataSource/EloquentDataSource.php
@@ -67,7 +67,7 @@ class EloquentDataSource extends DataSource
 	 */
 	public function registerQuery($event)
 	{
-		$trace = StackTrace::get();
+		$trace = StackTrace::get()->resolveViewName();
 		$caller = $trace->firstNonVendor([ 'itsgoingd', 'laravel', 'illuminate' ]);
 
 		$this->queries[] = [

--- a/Clockwork/DataSource/LaravelCacheDataSource.php
+++ b/Clockwork/DataSource/LaravelCacheDataSource.php
@@ -89,7 +89,7 @@ class LaravelCacheDataSource extends DataSource
 	 */
 	public function registerQuery(array $query)
 	{
-		$trace = StackTrace::get();
+		$trace = StackTrace::get()->resolveViewName();
 		$caller = $trace->firstNonVendor([ 'itsgoingd', 'laravel', 'illuminate' ]);
 
 		$this->queries[] = array_merge($query, [

--- a/Clockwork/DataSource/LaravelEventsDataSource.php
+++ b/Clockwork/DataSource/LaravelEventsDataSource.php
@@ -54,7 +54,7 @@ class LaravelEventsDataSource extends DataSource
 	{
 		if (! $this->shouldCollect($event)) return;
 
-		$trace = StackTrace::get();
+		$trace = StackTrace::get()->resolveViewName();
 		$firedAt = $trace->firstNonVendor([ 'itsgoingd', 'laravel', 'illuminate' ]);
 
 		$this->events[] = [

--- a/Clockwork/Helpers/Concerns/ResolvesViewName.php
+++ b/Clockwork/Helpers/Concerns/ResolvesViewName.php
@@ -1,0 +1,32 @@
+<?php namespace Clockwork\Helpers\Concerns;
+
+use Clockwork\Helpers\StackFrame;
+
+trait ResolvesViewName
+{
+	public function resolveViewName()
+	{
+		$viewFrame = $this->first(function ($frame) {
+			return preg_match('#^/storage/framework/views/[a-z0-9]+\.php$#', $frame->shortPath);
+		});
+
+		if (! $viewFrame) return $this;
+
+		$renderFrame = $this->first(function ($frame) {
+			return $frame->call == 'Illuminate\View\View->getContents()'
+				&& $frame->object instanceof \Illuminate\View\View;
+		});
+
+		if (! $renderFrame) return $this;
+
+		$resolvedViewFrame = new StackFrame(
+			[ 'file' => $renderFrame->object->getPath(), 'line' => $viewFrame->line ],
+			$this->basePath,
+			$this->vendorPath
+		);
+
+		array_splice($this->frames, array_search($viewFrame, $this->frames), 0, [ $resolvedViewFrame ]);
+
+		return $this;
+	}
+}

--- a/Clockwork/Helpers/StackTrace.php
+++ b/Clockwork/Helpers/StackTrace.php
@@ -2,6 +2,8 @@
 
 class StackTrace
 {
+	use Concerns\ResolvesViewName;
+
 	protected $frames;
 
 	protected $basePath;

--- a/Clockwork/Request/Log.php
+++ b/Clockwork/Request/Log.php
@@ -25,7 +25,7 @@ class Log extends AbstractLogger
 	 */
 	public function log($level = LogLevel::INFO, $message, array $context = [])
 	{
-		$trace = StackTrace::get();
+		$trace = StackTrace::get()->resolveViewName();
 		$caller = $trace->firstNonVendor([ 'itsgoingd', 'laravel', 'slim', 'monolog' ]);
 
 		$this->data[] = [


### PR DESCRIPTION
- adds support for resolving Laravel compiled view names in stack traces
- this is done by inserting a fake stack frame with the resolved view name on top of the logged stack
- the view name itself is resolved from a View object deeper in the stack
- feature request https://github.com/itsgoingd/clockwork/issues/260

<img width="1392" alt="screen shot 2018-07-07 at 22 18 51" src="https://user-images.githubusercontent.com/821582/42414334-d4cee2ca-8233-11e8-98ad-d3812e96367b.png">