### PR TITLE
Handle caller not found gracefully

### DIFF
--- a/Clockwork/Request/Log.php
+++ b/Clockwork/Request/Log.php
@@ -33,9 +33,9 @@ class Log extends AbstractLogger
 			'context' => (new Serializer)->normalize($context),
 			'level'   => $level,
 			'time'    => microtime(true),
-			'file'    => $caller->shortPath,
-			'line'    => $caller->line,
-			'trace'   => $this->collectStackTraces || ! empty($context['trace'])
+			'file'    => $caller ? $caller->shortPath : null,
+			'line'    => $caller ? $caller->line : null,
+			'trace'   => $caller && ($this->collectStackTraces || ! empty($context['trace']))
 				? (new Serializer)->trace($trace->framesBefore($caller)) : null
 		];
 	}


### PR DESCRIPTION
In our applications we ran into this issue multiple times, but i'm unsure this is the best way of handling it, so opening it for discussion.

What happens is then an error is triggered like a missing interface, the backtrace cannot be found which means the `$caller` is null. Instead of the original error being shown in the whoops screen, we see the following:

![shortpath](https://user-images.githubusercontent.com/1583095/45928119-da87a380-bf3e-11e8-8f95-bb2f4752b479.PNG)

Instead the error that should have been shown is the following:
![original-exception](https://user-images.githubusercontent.com/1583095/45928122-e1aeb180-bf3e-11e8-85f9-25f500695252.PNG)

What we currently do is opening the `Log.php` file, and removing the `file`, `line` and `trace` lines, but is a bit of a pain to do for every time an exception like this is thrown.

This fix ensures that if the caller cannot be found, the `file`, `line` and `trace` are set to `null`, so the original exception can pass trough.