### PR TITLE
Improved vanilla support

### DIFF
--- a/Clockwork/Clockwork.php
+++ b/Clockwork/Clockwork.php
@@ -275,9 +275,54 @@ class Clockwork implements LoggerInterface
 		return $this->getTimeline()->endEvent($name);
 	}
 
-	/**
-	 * Shortcut methods for recording subrequests
-	 */
+	// Shortcut methods for the Request object
+
+	// Add database query, takes query, bindings, duration and additional data - connection (connection name), file
+	// (caller file name), line (caller line number), trace (serialized trace), model (associated ORM model)
+	public function addDatabaseQuery($query, $bindings = [], $duration = null, $data = [])
+	{
+		return $this->getRequest()->addDatabaseQuery($query, $bindings, $duration, $data);
+	}
+
+	// Add cache query, takes type, key, value and additional data - connection (connection name), file
+	// (caller file name), line (caller line number), trace (serialized trace), expiration
+	public function addCacheQuery($type, $key, $value = null, $duration = null, $data = [])
+	{
+		return $this->getRequest()->addCacheQuery($type, $key, $value, $duration, $data);
+	}
+
+	// Add event, takes event name, data, time and additional data - listeners, file (caller file name), line (caller
+	// line number), trace (serialized trace)
+	public function addEvent($event, $eventData = null, $time = null, $data = [])
+	{
+		return $this->getRequest()->addEvent($event, $eventData, $time, $data);
+	}
+
+	// Add route, takes method, uri, action and additional data - name, middleware, before (before filters), after
+	// (after filters)
+	public function addRoute($method, $uri, $action, $data = [])
+	{
+		return $this->getRequest()->addRoute($method, $uri, $action, $data);
+	}
+
+	// Add route, takes method, uri, action and additional data - name, middleware, before (before filters), after
+	// (after filters)
+	public function addEmail($subject, $to, $from = null, $headers = [])
+	{
+		return $this->getRequest()->addEmail($subject, $to, $from, $headers);
+	}
+
+	// Add view, takes view name and data
+	public function addView($name, $data = [])
+	{
+		return $this->getRequest()->addView($name, $data);
+	}
+
+	// Record executed subrequest, takes the requested url, returned Clockwork ID and optional path if non-default
+	public function addSubrequest($url, $id, $path = null)
+	{
+		return $this->getRequest()->addSubrequest($url, $id, $path);
+	}
 
 	public function subrequest($url, $id, $path = null)
 	{

--- a/Clockwork/Clockwork.php
+++ b/Clockwork/Clockwork.php
@@ -107,7 +107,7 @@ class Clockwork implements LoggerInterface
 
 		// merge global log and timeline data with data collected from data sources
 		$this->request->log = array_merge($this->request->log, $this->log->toArray());
-		$this->request->timelineData = array_merge($this->request->timelineData, $this->timeline->finalize());
+		$this->request->timelineData = array_merge($this->request->timelineData, $this->timeline->finalize($this->request->time));
 
 		// sort log and timeline data by time
 		uasort($this->request->log, function($a, $b) {

--- a/Clockwork/Clockwork.php
+++ b/Clockwork/Clockwork.php
@@ -324,6 +324,7 @@ class Clockwork implements LoggerInterface
 		return $this->getRequest()->addSubrequest($url, $id, $path);
 	}
 
+	// DEPRECATED Use addSubrequest method
 	public function subrequest($url, $id, $path = null)
 	{
 		return $this->getRequest()->addSubrequest($url, $id, $path);

--- a/Clockwork/Request/Request.php
+++ b/Clockwork/Request/Request.php
@@ -1,5 +1,7 @@
 <?php namespace Clockwork\Request;
 
+use Clockwork\Helpers\Serializer;
+
 /**
  * Data structure representing a single application request
  */
@@ -235,6 +237,94 @@ class Request
 	public function toJson()
 	{
 		return json_encode($this->toArray(), \JSON_PARTIAL_OUTPUT_ON_ERROR);
+	}
+
+	// Add database query, takes query, bindings, duration and additional data - connection (connection name), file
+	// (caller file name), line (caller line number), trace (serialized trace), model (associated ORM model)
+	public function addDatabaseQuery($query, $bindings = [], $duration = null, $data = [])
+	{
+		$this->databaseQueries[] = [
+			'query'      => $query,
+			'bindings'   => $bindings,
+			'duration'   => $duration,
+			'connection' => isset($data['connection']) ? $data['connection'] : null,
+			'file'       => isset($data['file']) ? $data['file'] : null,
+			'line'       => isset($data['line']) ? $data['line'] : null,
+			'trace'      => isset($data['trace']) ? $data['trace'] : null,
+			'model'      => isset($data['model']) ? $data['model'] : null
+		];
+	}
+
+	// Add cache query, takes type, key, value and additional data - connection (connection name), file
+	// (caller file name), line (caller line number), trace (serialized trace), expiration
+	public function addCacheQuery($type, $key, $value = null, $duration = null, $data = [])
+	{
+		$this->cacheQueries[] = [
+			'type'       => $type,
+			'key'        => $key,
+			'value'      => (new Serializer)->normalize($value),
+			'duration'   => $duration,
+			'connection' => isset($data['connection']) ? $data['connection'] : null,
+			'file'       => isset($data['file']) ? $data['file'] : null,
+			'line'       => isset($data['line']) ? $data['line'] : null,
+			'trace'      => isset($data['trace']) ? $data['trace'] : null,
+			'expiration' => isset($data['expiration']) ? $data['expiration'] : null
+		];
+	}
+
+	// Add event, takes event name, data, time and additional data - listeners, file (caller file name), line (caller
+	// line number), trace (serialized trace)
+	public function addEvent($event, $eventData = null, $time = null, $data = [])
+	{
+		$this->events[] = [
+			'event'     => $event,
+			'data'      => (new Serializer)->normalize($eventData),
+			'time'      => $time,
+			'listeners' => isset($data['listeners']) ? $data['listeners'] : null,
+			'file'      => isset($data['file']) ? $data['file'] : null,
+			'line'      => isset($data['line']) ? $data['line'] : null,
+			'trace'     => isset($data['trace']) ? $data['trace'] : null
+		];
+	}
+
+	// Add route, takes method, uri, action and additional data - name, middleware, before (before filters), after
+	// (after filters)
+	public function addRoute($method, $uri, $action, $data = [])
+	{
+		$this->routes[] = [
+			'method'     => $method,
+			'uri'        => $uri,
+			'action'     => $action,
+			'name'       => isset($data['name']) ? $data['name'] : null,
+			'middleware' => isset($data['middleware']) ? $data['middleware'] : null,
+			'before'     => isset($data['before']) ? $data['before'] : null,
+			'after'      => isset($data['after']) ? $data['after'] : null
+		];
+	}
+
+	// Add route, takes method, uri, action and additional data - name, middleware, before (before filters), after
+	// (after filters)
+	public function addEmail($subject, $to, $from = null, $headers = [])
+	{
+		$this->emailsData[] = [
+			'data' => [
+				'subject' => $subject,
+				'to'      => $to,
+				'from'    => $from,
+				'headers' => (new Serializer)->normalize($headers)
+			]
+		];
+	}
+
+	// Add view, takes view name and data
+	public function addView($name, $data = [])
+	{
+		$this->viewsData[] = [
+			'data' => [
+				'name' => $name,
+				'data' => (new Serializer)->normalize($data)
+			]
+		];
 	}
 
 	/**

--- a/Clockwork/Support/Vanilla/Clockwork.php
+++ b/Clockwork/Support/Vanilla/Clockwork.php
@@ -1,0 +1,114 @@
+<?php namespace Clockwork\Support\Vanilla;
+
+use Clockwork\Clockwork as BaseClockwork;
+use Clockwork\DataSource\PhpDataSource;
+use Clockwork\Helpers\ServerTiming;
+use Clockwork\Storage\FileStorage;
+
+class Clockwork
+{
+	protected $config;
+	protected $clockwork;
+
+	protected static $defaultInstance;
+
+	public function __construct($config = [])
+	{
+		$this->config = array_merge(include __DIR__ . '/config.php', $config);
+
+		$this->clockwork = new BaseClockwork;
+
+		$this->clockwork->addDataSource(new PhpDataSource);
+		$this->clockwork->setStorage($this->resolveStorage());
+
+		$this->clockwork->getLog()->collectStackTraces($this->config['collect_stack_traces']);
+
+		if ($this->config['register_helpers']) include __DIR__ . '/helpers.php';
+
+		$this->clockwork->getTimeline()->startEvent('total', 'Total execution time.', 'start');
+	}
+
+	public static function init($config = [])
+	{
+		return static::$defaultInstance = new static($config);
+	}
+
+	public static function instance()
+	{
+		return static::$defaultInstance;
+	}
+
+	public function requestProcessed()
+	{
+		if (! $this->config['enable'] && ! $this->config['collect_data_always']) return;
+
+		$this->clockwork->getTimeline()->endEvent('total');
+
+		$this->clockwork->resolveRequest()->storeRequest();
+
+		if (! $this->config['enable']) return;
+
+		header('X-Clockwork-Id: ' . $this->getRequest()->id);
+		header('X-Clockwork-Version: ' . BaseClockwork::VERSION);
+
+		if ($this->config['api_uri'] != '/__clockwork/') {
+			header('X-Clockwork-Path: ' . $this->config['api_uri']);
+		}
+
+		foreach ($this->config['headers'] as $headerName => $headerValue) {
+			header("X-Clockwork-Header-{$headerName}: {$headerValue}");
+		}
+
+		if (($eventsCount = $this->config['server_timing']) !== false) {
+			header('Server-Timing: ' . ServerTiming::fromRequest($this->clockwork->getRequest(), $eventsCount)->value());
+		}
+	}
+
+	public function returnMetadata($request = null)
+	{
+		if (! $this->config['enable']) return;
+
+		header('Content-Type: application/json');
+
+		echo $this->getStorage()->find($request ?: $_GET['request'])->toJson();
+	}
+
+	public function resolveStorage()
+	{
+		if ($this->config['storage'] == 'sql') {
+			$database = $this->config['storage_sql_database'];
+			$table = $this->config['storage_sql_table'];
+
+			$storage = new SqlStorage(
+				$this->config['storage_sql_database'],
+				$this->config['storage_sql_table'],
+				$this->config['storage_sql_username'],
+				$this->config['storage_sql_password'],
+				$this->config['storage_expiration']
+			);
+		} else {
+			$storage = new FileStorage(
+				$this->config['storage_files_path'], 0700, $this->config['storage_expiration']
+			);
+		}
+
+		$storage->filter = $this->config['filter'];
+
+		return $storage;
+	}
+
+	public function getClockwork()
+	{
+		return $this->clockwork;
+	}
+
+	public function __call($method, $args = [])
+	{
+		return call_user_func_array([ $this->getClockwork(), $method ], $args);
+	}
+
+	public static function __callStatic($method, $args = [])
+	{
+		return call_user_func_array([ static::instance(), $method ], $args);
+	}
+}

--- a/Clockwork/Support/Vanilla/config.php
+++ b/Clockwork/Support/Vanilla/config.php
@@ -1,0 +1,161 @@
+<?php
+
+return [
+
+	/*
+	|--------------------------------------------------------------------------
+	| Enable Clockwork
+	|--------------------------------------------------------------------------
+	|
+	| You can explicitly enable or disable Clockwork here. When disabled,
+	| the storeRequest and returnRequest methods will be no-ops. This provides
+	| a convenient way to disable Clockwork in production.
+	|
+	*/
+
+	'enable' => isset($_ENV['CLOCKWORK_ENABLE']) ? $_ENV['CLOCKWORK_ENABLE'] : true,
+
+	/*
+	|--------------------------------------------------------------------------
+	| Enable data collection, when Clockwork is disabled
+	|--------------------------------------------------------------------------
+	|
+	| This setting controls, whether data about application requests will be
+	| recorded even when Clockwork is disabled (useful for later analysis).
+	| Default: false
+	|
+	*/
+
+	'collect_data_always' => isset($_ENV['CLOCKWORK_COLLECT_DATA_ALWAYS']) ? $_ENV['CLOCKWORK_COLLECT_DATA_ALWAYS'] : false,
+
+	/*
+	|--------------------------------------------------------------------------
+	| Clockwork API URI
+	|--------------------------------------------------------------------------
+	|
+	| URI to the script calling returnRequest to return Clockwork metadata to
+	| the client app. See installation instructions for details.
+	| Default: '/__clockwork/'
+	|
+	*/
+
+	'api' => isset($_ENV['CLOCKWORK_API']) ? $_ENV['CLOCKWORK_API'] : '/__clockwork/',
+
+	/*
+	|--------------------------------------------------------------------------
+	| Metadata storage
+	|--------------------------------------------------------------------------
+	|
+	| You can configure how are the metadata collected by Clockwork stored.
+	| Valid options are: files or sql.
+	| Files storage stores the metadata in one-per-request files in a specified
+	| directory.
+	| Sql storage stores the metadata as rows in a sql database. You can specify
+	| the database by it's PDO connection string. Database table will be
+	| automatically created.
+	| Sql storage requires PDO.
+	|
+	*/
+
+	'storage' => isset($_ENV['CLOCKWORK_STORAGE']) ? $_ENV['CLOCKWORK_STORAGE'] : 'files',
+
+	'storage_files_path' => isset($_ENV['CLOCKWORK_STORAGE_FILES_PATH']) ? $_ENV['CLOCKWORK_STORAGE_FILES_PATH'] : __DIR__ . '/../../../../../clockwork',
+
+	'storage_sql_database' => isset($_ENV['CLOCKWORK_STORAGE_SQL_DATABASE']) ? $_ENV['CLOCKWORK_STORAGE_SQL_DATABASE'] : 'sqlite:' . __DIR__ . '/../../../../../clockwork.sqlite',
+	'storage_sql_username' => isset($_ENV['CLOCKWORK_STORAGE_SQL_USERNAME']) ? $_ENV['CLOCKWORK_STORAGE_SQL_USERNAME'] : null,
+	'storage_sql_password' => isset($_ENV['CLOCKWORK_STORAGE_SQL_PASSWORD']) ? $_ENV['CLOCKWORK_STORAGE_SQL_PASSWORD'] : null,
+	'storage_sql_table'    => isset($_ENV['CLOCKWORK_STORAGE_SQL_TABLE']) ? $_ENV['CLOCKWORK_STORAGE_SQL_TABLE'] : 'clockwork',
+
+	/*
+	|--------------------------------------------------------------------------
+	| Metadata expiration
+	|--------------------------------------------------------------------------
+	|
+	| Maximum lifetime of the metadata in minutes, metadata for older requests
+	| will automatically be deleted when storing new requests.
+	| When set to false, metadata will never be deleted.
+	| Default: 1 week
+	|
+	*/
+
+	'storage_expiration' => isset($_ENV['CLOCKWORK_STORAGE_EXPIRATION']) ? $_ENV['CLOCKWORK_STORAGE_EXPIRATION'] : 60 * 24 * 7,
+
+	/*
+	|--------------------------------------------------------------------------
+	| Filter collected data
+	|--------------------------------------------------------------------------
+	|
+	| You can filter collected data by specifying what you don't want to collect
+	| here.
+	|
+	*/
+
+	'filter' => [
+		'cacheQueries', // collecting cache queries in cache-heavy might have a negative performance impact and use a lot of disk space
+		'routes', // collecting routes data on every request might use a lot of disk space
+		'viewsData', // collecting views data, including all variables passed to the view on every request might use a lot of disk space
+	],
+
+	/*
+	|--------------------------------------------------------------------------
+	| Enable collecting of stack traces
+	|--------------------------------------------------------------------------
+	|
+	| This setting controls, whether log messages and certain data sources, like
+	| the database or cache data sources, should collect stack traces.
+	| You might want to disable this if you are collecting 100s of queries or
+	| log messages, as the stack traces can considerably increase the metadata size.
+	| You can force collecting of stack trace for a single log call by passing
+	| [ 'trace' => true ] as $context.
+	| Default: true
+	|
+	*/
+
+	'collect_stack_traces' => isset($_ENV['CLOCKWORK_COLLECT_STACK_TRACES']) ? $_ENV['CLOCKWORK_COLLECT_STACK_TRACES'] : true,
+
+	/*
+	|--------------------------------------------------------------------------
+	| Register helpers
+	|--------------------------------------------------------------------------
+	|
+	| This setting controls whether the "clock" helper function will be registered. You can use the "clock" function to
+	| quickly log something to Clockwork or access the Clockwork instance.
+	|
+	*/
+
+	'register_helpers' => isset($_ENV['CLOCKWORK_REGISTER_HELPERS']) ? $_ENV['CLOCKWORK_REGISTER_HELPERS'] : false,
+
+	/*
+	|--------------------------------------------------------------------------
+	| Send Headers for AJAX request
+	|--------------------------------------------------------------------------
+	|
+	| When trying to collect data the AJAX method can sometimes fail if it is
+	| missing required headers. For example, an API might require a version
+	| number using Accept headers to route the HTTP request to the correct
+	| codebase.
+	|
+	*/
+
+	'headers' => [
+		// 'Accept' => 'application/vnd.com.whatever.v1+json',
+	],
+
+	/*
+	|--------------------------------------------------------------------------
+	| Server-Timing
+	|--------------------------------------------------------------------------
+	|
+	| Clockwork supports the W3C Server Timing specification, which allows for
+	| collecting a simple performance metrics in a cross-browser way. Eg. in
+	| Chrome, your app, database and timeline event timings will be shown
+	| in the Dev Tools network tab.
+	| This setting specifies the max number of timeline events that will be sent.
+	| When set to false, Server-Timing headers will not be set.
+	| Default: 10
+	|
+	*/
+
+	'server_timing' => isset($_ENV['CLOCKWORK_SERVER_TIMING']) ? $_ENV['CLOCKWORK_SERVER_TIMING'] : 10
+
+];

--- a/Clockwork/Support/Vanilla/helpers.php
+++ b/Clockwork/Support/Vanilla/helpers.php
@@ -1,0 +1,23 @@
+<?php
+
+use Clockwork\Support\Vanilla\Clockwork;
+
+if (! function_exists('clock')) {
+	/**
+	 * Log a message to Clockwork, returns Clockwork instance when called with no arguments.
+	 */
+	function clock()
+	{
+		$arguments = func_get_args();
+
+		if (empty($arguments)) {
+			return Clockwork::instance();
+		}
+
+		foreach ($arguments as $argument) {
+			Clockwork::debug($argument);
+		}
+
+		return reset($arguments);
+	}
+}


### PR DESCRIPTION
- added vanilla php integration to make it easier to use Clockwork with vanilla php apps
- exposes a simple array or env-variables based configuration
- easy to use with or without router
- manages the initial bootstrap, sends correct headers, implements Clockwork rest api, supports clock helper, stack traces, server-timing etc.
- does not support Clockwork Web UI and authentication atm
- includes a simple support for PSR-7 enabled apps
- added simple way to manually register database queries, cache queries, events, etc.
- [temporary documentation](https://gist.github.com/itsgoingd/0223498a5043b7ca1643ef6e6ad7ee53)