### PR TITLE
Improved logging of exceptions

### DIFF
--- a/Clockwork/Helpers/Serializer.php
+++ b/Clockwork/Helpers/Serializer.php
@@ -99,4 +99,17 @@ class Serializer
 			];
 		}, $trace->frames());
 	}
+
+	public function exception(\Exception $exception)
+	{
+		return [
+			'type'     => get_class($exception),
+			'message'  => $exception->getMessage(),
+			'code'     => $exception->getCode(),
+			'file'     => $exception->getFile(),
+			'line'     => $exception->getLine(),
+			'trace'    => $this->trace(StackTrace::from($exception->getTrace())),
+			'previous' => $exception->getPrevious() ? $this->exception($exception->getPrevious()) : null
+		];
+	}
 }

--- a/Clockwork/Helpers/StackTrace.php
+++ b/Clockwork/Helpers/StackTrace.php
@@ -11,14 +11,19 @@ class StackTrace
 
 	public static function get()
 	{
+		return static::from(
+			debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS)
+		);
+	}
+
+	public static function from(array $trace)
+	{
 		$basePath = static::resolveBasePath();
 		$vendorPath = static::resolveVendorPath();
 
-		$backbacktrace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS);
-
 		return new static(array_map(function ($frame) use ($basePath, $vendorPath) {
 			return new StackFrame($frame, $basePath, $vendorPath);
-		}, $backbacktrace), $basePath, $vendorPath);
+		}, $trace), $basePath, $vendorPath);
 	}
 
 	public function __construct(array $frames, $basePath, $vendorPath)


### PR DESCRIPTION
- added special processing for exceptions in log messages context to support new exceptions UI in Clockwork apps
- to turn off the new behavior specify `[ 'raw' => true ]` in the message context
- Chrome PR - https://github.com/itsgoingd/clockwork-chrome/pull/71