### PR TITLE
DBALDataSource throws exception for custom types that do not implement __toString()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # osx noise
 .DS_Store
+composer.lock
+vendor/
+.idea/

--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,8 @@
                 "Clockwork": "Clockwork\\Support\\Laravel\\Facade"
             }
         }
+    },
+    "require-dev": {
+        "doctrine/dbal": "^2.5.13"
     }
 }


### PR DESCRIPTION
DBALDataSource will insert query parameters back into the SQL. It will throw an exception when the parameter object does not implement `__toString()` even though the connection might be able to convert the value just fine. It's not desirable for a logging tool to throw any exceptions at all imho.

I suggest using the passed types in combination with `\Doctrine\DBAL\Types\Type::getType()` to try to convert the values using the actual connection first.