### PR TITLE
Added support for collecting raw and json request data (body)

### DIFF
--- a/Clockwork/DataSource/PhpDataSource.php
+++ b/Clockwork/DataSource/PhpDataSource.php
@@ -22,6 +22,7 @@ class PhpDataSource extends DataSource
 		$request->headers        = $this->getRequestHeaders();
 		$request->getData        = $this->getGetData();
 		$request->postData       = $this->getPostData();
+		$request->requestData    = $this->getRequestData();
 		$request->sessionData    = $this->getSessionData();
 		$request->cookies        = $this->getCookies();
 		$request->responseStatus = $this->getResponseStatus();
@@ -53,6 +54,17 @@ class PhpDataSource extends DataSource
 	protected function getPostData()
 	{
 		return $this->removePasswords((new Serializer)->normalizeEach($_POST));
+	}
+
+	// Return request body data (attempt to parse as json, replace unserializable items, attempt to remove passwords)
+	protected function getRequestData()
+	{
+		$requestData = file_get_contents('php://input');
+		$requestJsonData = json_decode($requestData, true);
+
+		return $requestJsonData
+			? $this->removePasswords((new Serializer)->normalizeEach($requestJsonData))
+			: $requestData;
 	}
 
 	/**

--- a/Clockwork/Request/Request.php
+++ b/Clockwork/Request/Request.php
@@ -57,6 +57,9 @@ class Request
 	 */
 	public $postData = [];
 
+	// Request data array
+	public $requestData = [];
+
 	/**
 	 * Session data array
 	 */
@@ -206,6 +209,7 @@ class Request
 			'controller'        => $this->controller,
 			'getData'           => $this->getData,
 			'postData'          => $this->postData,
+			'requestData'       => $this->requestData,
 			'sessionData'       => $this->sessionData,
 			'authenticatedUser' => $this->authenticatedUser,
 			'cookies'           => $this->cookies,

--- a/Clockwork/Storage/SqlStorage.php
+++ b/Clockwork/Storage/SqlStorage.php
@@ -21,18 +21,18 @@ class SqlStorage extends Storage
 
 	// List of all fields in the Clockwork requests table
 	protected $fields = [
-		'id', 'version', 'time', 'method', 'url', 'uri', 'headers', 'controller', 'getData', 'postData', 'sessionData',
-		'authenticatedUser', 'cookies', 'responseTime', 'responseStatus', 'responseDuration', 'memoryUsage',
-		'databaseQueries', 'databaseDuration', 'cacheQueries', 'cacheReads', 'cacheHits', 'cacheWrites', 'cacheDeletes',
-		'cacheTime', 'timelineData', 'log', 'events', 'routes', 'emailsData', 'viewsData', 'userData', 'subrequests',
-		'xdebug'
+		'id', 'version', 'time', 'method', 'url', 'uri', 'headers', 'controller', 'getData', 'postData', 'requestData',
+		'sessionData', 'authenticatedUser', 'cookies', 'responseTime', 'responseStatus', 'responseDuration',
+		'memoryUsage', 'databaseQueries', 'databaseDuration', 'cacheQueries', 'cacheReads', 'cacheHits', 'cacheWrites',
+		'cacheDeletes', 'cacheTime', 'timelineData', 'log', 'events', 'routes', 'emailsData', 'viewsData', 'userData',
+		'subrequests', 'xdebug'
 	];
 
 	// List of Request keys that need to be serialized before they can be stored in database
 	protected $needsSerialization = [
-		'headers', 'getData', 'postData', 'sessionData', 'authenticatedUser', 'cookies', 'databaseQueries',
-		'cacheQueries', 'timelineData', 'log', 'events', 'routes', 'emailsData', 'viewsData', 'userData', 'subrequests',
-		'xdebug'
+		'headers', 'getData', 'postData', 'requestData', 'sessionData', 'authenticatedUser', 'cookies',
+		'databaseQueries', 'cacheQueries', 'timelineData', 'log', 'events', 'routes', 'emailsData', 'viewsData',
+		'userData', 'subrequests', 'xdebug'
 	];
 
 	// Return a new storage, takes PDO object or DSN and optionally a table name and database credentials as arguments
@@ -152,6 +152,7 @@ class SqlStorage extends Storage
 				$this->quote('controller') . ' VARCHAR(250) NULL, ' .
 				$this->quote('getData') . " {$textType} NULL, " .
 				$this->quote('postData') . " {$textType} NULL, " .
+				$this->quote('requestData') . " {$textType} NULL, " .
 				$this->quote('sessionData') . " {$textType} NULL, " .
 				$this->quote('authenticatedUser') . " {$textType} NULL, " .
 				$this->quote('cookies') . " {$textType} NULL, " .


### PR DESCRIPTION
- added support for collecting raw and json request bodies (similar to get/post data)
- implemented in PhpDataSource, we try to parse the body as json and fall back to collecting the raw body
- useful for eg. api requests that often use json request bodies instead for form data
- app PR https://github.com/underground-works/clockwork-app/pull/1
- FR https://github.com/itsgoingd/clockwork/issues/267