### PR TITLE
Added support for collecting Redis commands

### DIFF
--- a/Clockwork/DataSource/LaravelRedisDataSource.php
+++ b/Clockwork/DataSource/LaravelRedisDataSource.php
@@ -1,0 +1,83 @@
+<?php namespace Clockwork\DataSource;
+
+use Clockwork\Helpers\Serializer;
+use Clockwork\Helpers\StackTrace;
+use Clockwork\Request\Request;
+
+use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
+
+/**
+ * Data source for Laravel redis component, provides redis queries
+ */
+class LaravelRedisDataSource extends DataSource
+{
+	/**
+	 * Event dispatcher
+	 */
+	protected $eventDispatcher;
+
+	/**
+	 * Executed redis commands
+	 */
+	protected $commands = [];
+
+	/**
+	 * Create a new data source instance, takes an event dispatcher as argument
+	 */
+	public function __construct(EventDispatcher $eventDispatcher)
+	{
+		$this->eventDispatcher = $eventDispatcher;
+	}
+
+	/**
+	 * Start listening to redis events
+	 */
+	public function listenToEvents()
+	{
+		$this->eventDispatcher->listen(\Illuminate\Redis\Events\CommandExecuted::class, function ($event) {
+			$this->registerCommand([
+				'command'    => $event->command,
+				'parameters' => $event->parameters,
+				'duration'   => $event->time,
+				'connection' => $event->connectionName
+			]);
+		});
+	}
+
+	/**
+	 * Adds redis commands to the request
+	 */
+	public function resolve(Request $request)
+	{
+		$request->redisCommands = array_merge($request->redisCommands, $this->getCommands());
+
+		return $request;
+	}
+
+	/**
+	 * Registers a new command, resolves caller file and line no
+	 */
+	public function registerCommand(array $command)
+	{
+		$trace = StackTrace::get()->resolveViewName();
+		$caller = $trace->firstNonVendor([ 'itsgoingd', 'laravel', 'illuminate' ]);
+
+		$this->commands[] = array_merge($command, [
+			'file'  => $caller->shortPath,
+			'line'  => $caller->line,
+			'trace' => $this->collectStackTraces ? (new Serializer)->trace($trace->framesBefore($caller)) : null
+		]);
+	}
+
+	/**
+	 * Returns an array of redis commands in Clockwork metadata format
+	 */
+	protected function getCommands()
+	{
+		return array_map(function ($query) {
+			return array_merge($query, [
+				'parameters' => isset($query['parameters']) ? (new Serializer)->normalize($query['parameters']) : null
+			]);
+		}, $this->commands);
+	}
+}

--- a/Clockwork/Request/Request.php
+++ b/Clockwork/Request/Request.php
@@ -121,6 +121,9 @@ class Request
 	 */
 	public $cacheTime;
 
+	// Redis commands
+	public $redisCommands = [];
+
 	/**
 	 * Timeline data array
 	 */
@@ -225,6 +228,7 @@ class Request
 			'cacheWrites'       => $this->cacheWrites,
 			'cacheDeletes'      => $this->cacheDeletes,
 			'cacheTime'         => $this->cacheTime,
+			'redisCommands'     => $this->redisCommands,
 			'timelineData'      => $this->timelineData,
 			'log'               => array_values($this->log),
 			'events'            => $this->events,

--- a/Clockwork/Storage/SqlStorage.php
+++ b/Clockwork/Storage/SqlStorage.php
@@ -24,15 +24,15 @@ class SqlStorage extends Storage
 		'id', 'version', 'time', 'method', 'url', 'uri', 'headers', 'controller', 'getData', 'postData', 'requestData',
 		'sessionData', 'authenticatedUser', 'cookies', 'responseTime', 'responseStatus', 'responseDuration',
 		'memoryUsage', 'databaseQueries', 'databaseDuration', 'cacheQueries', 'cacheReads', 'cacheHits', 'cacheWrites',
-		'cacheDeletes', 'cacheTime', 'timelineData', 'log', 'events', 'routes', 'emailsData', 'viewsData', 'userData',
-		'subrequests', 'xdebug'
+		'cacheDeletes', 'cacheTime', 'redisCommands', 'timelineData', 'log', 'events', 'routes', 'emailsData',
+		'viewsData', 'userData', 'subrequests', 'xdebug'
 	];
 
 	// List of Request keys that need to be serialized before they can be stored in database
 	protected $needsSerialization = [
 		'headers', 'getData', 'postData', 'requestData', 'sessionData', 'authenticatedUser', 'cookies',
-		'databaseQueries', 'cacheQueries', 'timelineData', 'log', 'events', 'routes', 'emailsData', 'viewsData',
-		'userData', 'subrequests', 'xdebug'
+		'databaseQueries', 'cacheQueries', 'redisCommands', 'timelineData', 'log', 'events', 'routes', 'emailsData',
+		'viewsData', 'userData', 'subrequests', 'xdebug'
 	];
 
 	// Return a new storage, takes PDO object or DSN and optionally a table name and database credentials as arguments
@@ -168,6 +168,7 @@ class SqlStorage extends Storage
 				$this->quote('cacheWrites') . ' INTEGER NULL, ' .
 				$this->quote('cacheDeletes') . ' INTEGER NULL, ' .
 				$this->quote('cacheTime') . ' DOUBLE PRECISION NULL, ' .
+				$this->quote('redisCommands') . " {$textType} NULL, " .
 				$this->quote('timelineData') . " {$textType} NULL, " .
 				$this->quote('log') . " {$textType} NULL, " .
 				$this->quote('events') . " {$textType} NULL, " .

--- a/Clockwork/Support/Laravel/ClockworkSupport.php
+++ b/Clockwork/Support/Laravel/ClockworkSupport.php
@@ -194,7 +194,7 @@ class ClockworkSupport
 
 	public function isCollectingRedisCommands()
 	{
-		return ! in_array('redis', $this->getFilter());
+		return ! in_array('redis', $this->getFilter()) && method_exists(\Illuminate\Redis\RedisManager::class, 'enableEvents');
 	}
 
 	public function isCollectingEvents()

--- a/Clockwork/Support/Laravel/ClockworkSupport.php
+++ b/Clockwork/Support/Laravel/ClockworkSupport.php
@@ -192,6 +192,11 @@ class ClockworkSupport
 		return ! in_array('cache', $this->getFilter());
 	}
 
+	public function isCollectingRedisCommands()
+	{
+		return ! in_array('redis', $this->getFilter());
+	}
+
 	public function isCollectingEvents()
 	{
 		return ! in_array('events', $this->getFilter());

--- a/Clockwork/Support/Lumen/ClockworkSupport.php
+++ b/Clockwork/Support/Lumen/ClockworkSupport.php
@@ -204,6 +204,11 @@ class ClockworkSupport
 		return ! in_array('cache', $this->getFilter());
 	}
 
+	public function isCollectingRedisCommands()
+	{
+		return ! in_array('redis', $this->getFilter());
+	}
+
 	public function isCollectingEvents()
 	{
 		return ! in_array('events', $this->getFilter());


### PR DESCRIPTION
- added support for collecting executed Redis commands (command, parameters, duration, connection, trace)
- ootb support for Laravel and Lumen
- app PR https://github.com/underground-works/clockwork-app/pull/2
- FR https://github.com/itsgoingd/clockwork/issues/290