### PR TITLE
Added support for collecting dispatched queue jobs

### DIFF
--- a/Clockwork/DataSource/LaravelQueueDataSource.php
+++ b/Clockwork/DataSource/LaravelQueueDataSource.php
@@ -1,0 +1,87 @@
+<?php namespace Clockwork\DataSource;
+
+use Clockwork\Helpers\Serializer;
+use Clockwork\Helpers\StackTrace;
+use Clockwork\Request\Request;
+
+use Illuminate\Queue\Queue;
+
+/**
+ * Data source for Laravel queue component, provides dispatched queue jobs
+ */
+class LaravelQueueDataSource extends DataSource
+{
+	/**
+	 * Queue instance
+	 */
+	protected $queue;
+
+	/**
+	 * Dispatched queue commands
+	 */
+	protected $jobs = [];
+
+	/**
+	 * Create a new data source instance, takes an event dispatcher as argument
+	 */
+	public function __construct(Queue $queue)
+	{
+		$this->queue = $queue;
+	}
+
+	/**
+	 * Start listening to queue events
+	 */
+	public function listenToEvents()
+	{
+		$this->queue->createPayloadUsing(function ($connection, $queue, $payload) {
+			$this->registerJob([
+				'connection' => $connection,
+				'queue'      => $queue,
+				'name'       => $payload['displayName'],
+				'data'       => isset($payload['data']['command']) ? $payload['data']['command'] : null,
+				'maxTries'   => $payload['maxTries'],
+				'timeout'    => $payload['timeout']
+			]);
+
+			return [];
+		});
+	}
+
+	/**
+	 * Adds dispatched queue jobs to the request
+	 */
+	public function resolve(Request $request)
+	{
+		$request->queueJobs = array_merge($request->queueJobs, $this->getJobs());
+
+		return $request;
+	}
+
+	/**
+	 * Registers a new queue job, resolves caller file and line no
+	 */
+	public function registerJob(array $job)
+	{
+		$trace = StackTrace::get()->resolveViewName();
+		$caller = $trace->firstNonVendor([ 'itsgoingd', 'laravel', 'illuminate' ]);
+
+		$this->jobs[] = array_merge($job, [
+			'file'  => $caller->shortPath,
+			'line'  => $caller->line,
+			'trace' => $this->collectStackTraces ? (new Serializer)->trace($trace->framesBefore($caller)) : null
+		]);
+	}
+
+	/**
+	 * Returns an array of dispatched queue jobs commands in Clockwork metadata format
+	 */
+	protected function getJobs()
+	{
+		return array_map(function ($query) {
+			return array_merge($query, [
+				'data' => isset($query['data']) ? (new Serializer)->normalize($query['data']) : null
+			]);
+		}, $this->jobs);
+	}
+}

--- a/Clockwork/Request/Request.php
+++ b/Clockwork/Request/Request.php
@@ -124,6 +124,9 @@ class Request
 	// Redis commands
 	public $redisCommands = [];
 
+	// Dispatched queue jobs
+	public $queueJobs = [];
+
 	/**
 	 * Timeline data array
 	 */
@@ -229,6 +232,7 @@ class Request
 			'cacheDeletes'      => $this->cacheDeletes,
 			'cacheTime'         => $this->cacheTime,
 			'redisCommands'     => $this->redisCommands,
+			'queueJobs'         => $this->queueJobs,
 			'timelineData'      => $this->timelineData,
 			'log'               => array_values($this->log),
 			'events'            => $this->events,

--- a/Clockwork/Storage/SqlStorage.php
+++ b/Clockwork/Storage/SqlStorage.php
@@ -24,15 +24,15 @@ class SqlStorage extends Storage
 		'id', 'version', 'time', 'method', 'url', 'uri', 'headers', 'controller', 'getData', 'postData', 'requestData',
 		'sessionData', 'authenticatedUser', 'cookies', 'responseTime', 'responseStatus', 'responseDuration',
 		'memoryUsage', 'databaseQueries', 'databaseDuration', 'cacheQueries', 'cacheReads', 'cacheHits', 'cacheWrites',
-		'cacheDeletes', 'cacheTime', 'redisCommands', 'timelineData', 'log', 'events', 'routes', 'emailsData',
-		'viewsData', 'userData', 'subrequests', 'xdebug'
+		'cacheDeletes', 'cacheTime', 'redisCommands', 'queueJobs', 'timelineData', 'log', 'events', 'routes',
+		'emailsData', 'viewsData', 'userData', 'subrequests', 'xdebug'
 	];
 
 	// List of Request keys that need to be serialized before they can be stored in database
 	protected $needsSerialization = [
 		'headers', 'getData', 'postData', 'requestData', 'sessionData', 'authenticatedUser', 'cookies',
-		'databaseQueries', 'cacheQueries', 'redisCommands', 'timelineData', 'log', 'events', 'routes', 'emailsData',
-		'viewsData', 'userData', 'subrequests', 'xdebug'
+		'databaseQueries', 'cacheQueries', 'redisCommands', 'queueJobs', 'timelineData', 'log', 'events', 'routes',
+		'emailsData', 'viewsData', 'userData', 'subrequests', 'xdebug'
 	];
 
 	// Return a new storage, takes PDO object or DSN and optionally a table name and database credentials as arguments
@@ -169,6 +169,7 @@ class SqlStorage extends Storage
 				$this->quote('cacheDeletes') . ' INTEGER NULL, ' .
 				$this->quote('cacheTime') . ' DOUBLE PRECISION NULL, ' .
 				$this->quote('redisCommands') . " {$textType} NULL, " .
+				$this->quote('queueJobs') . " {$textType} NULL, " .
 				$this->quote('timelineData') . " {$textType} NULL, " .
 				$this->quote('log') . " {$textType} NULL, " .
 				$this->quote('events') . " {$textType} NULL, " .

--- a/Clockwork/Support/Laravel/ClockworkSupport.php
+++ b/Clockwork/Support/Laravel/ClockworkSupport.php
@@ -194,7 +194,14 @@ class ClockworkSupport
 
 	public function isCollectingRedisCommands()
 	{
-		return ! in_array('redis', $this->getFilter()) && method_exists(\Illuminate\Redis\RedisManager::class, 'enableEvents');
+		return ! in_array('redis', $this->getFilter())
+			&& method_exists(\Illuminate\Redis\RedisManager::class, 'enableEvents');
+	}
+
+	public function isCollectingQueueJobs()
+	{
+		return ! in_array('queueJob', $this->getFilter())
+			&& method_exists(\Illuminate\Queue\Queue::class, 'createPayloadUsing');
 	}
 
 	public function isCollectingEvents()

--- a/Clockwork/Support/Lumen/ClockworkSupport.php
+++ b/Clockwork/Support/Lumen/ClockworkSupport.php
@@ -206,7 +206,14 @@ class ClockworkSupport
 
 	public function isCollectingRedisCommands()
 	{
-		return ! in_array('redis', $this->getFilter());
+		return ! in_array('redis', $this->getFilter())
+			&& method_exists(\Illuminate\Redis\RedisManager::class, 'enableEvents');
+	}
+
+	public function isCollectingQueueJobs()
+	{
+		return ! in_array('queueJob', $this->getFilter())
+			&& method_exists(\Illuminate\Queue\Queue::class, 'createPayloadUsing');
 	}
 
 	public function isCollectingEvents()


### PR DESCRIPTION
- added support for collecting dispatched queue jobs (name, payload, max tries, timeout, queue, connection)
- ootb support for Laravel and Lumen
- app PR https://github.com/underground-works/clockwork-app/pull/3