### PR TITLE
Slow database queries tagging & query counters

### DIFF
--- a/Clockwork/DataSource/EloquentDataSource.php
+++ b/Clockwork/DataSource/EloquentDataSource.php
@@ -24,6 +24,9 @@ class EloquentDataSource extends DataSource
 	 */
 	protected $queries = [];
 
+	// Query execution time threshold in ms after which the query is marked as slow
+	protected $slowThreshold;
+
 	/**
 	 * Model name to associate with the next executed query, used to map queries to models
 	 */
@@ -32,10 +35,11 @@ class EloquentDataSource extends DataSource
 	/**
 	 * Create a new data source instance, takes a database manager and an event dispatcher as arguments
 	 */
-	public function __construct(ConnectionResolverInterface $databaseManager, EventDispatcher $eventDispatcher)
+	public function __construct(ConnectionResolverInterface $databaseManager, EventDispatcher $eventDispatcher, $slowThreshold = null)
 	{
 		$this->databaseManager = $databaseManager;
 		$this->eventDispatcher = $eventDispatcher;
+		$this->slowThreshold   = $slowThreshold;
 	}
 
 	/**
@@ -167,7 +171,8 @@ class EloquentDataSource extends DataSource
 				'file'       => $query['file'],
 				'line'       => $query['line'],
 				'trace'      => $query['trace'],
-				'model'      => $query['model']
+				'model'      => $query['model'],
+				'tags'       => $this->slowThreshold !== null && $query['time'] > $this->slowThreshold ? [ 'slow' ] : []
 			];
 		}, $this->queries);
 	}

--- a/Clockwork/Request/Request.php
+++ b/Clockwork/Request/Request.php
@@ -91,6 +91,19 @@ class Request
 	 */
 	public $databaseQueries = [];
 
+	// Database queries count
+	public $databaseQueriesCount;
+
+	// Database slow queries count
+	public $databaseSlowQueries;
+
+	// Database query counts of a particular type
+	public $databaseSelects;
+	public $databaseInserts;
+	public $databaseUpdates;
+	public $databaseDeletes;
+	public $databaseOthers;
+
 	/**
 	 * Cache queries array
 	 */
@@ -205,45 +218,52 @@ class Request
 	public function toArray()
 	{
 		return [
-			'id'                => $this->id,
-			'version'           => $this->version,
-			'time'              => $this->time,
-			'method'            => $this->method,
-			'url'               => $this->url,
-			'uri'               => $this->uri,
-			'headers'           => $this->headers,
-			'controller'        => $this->controller,
-			'getData'           => $this->getData,
-			'postData'          => $this->postData,
-			'requestData'       => $this->requestData,
-			'sessionData'       => $this->sessionData,
-			'authenticatedUser' => $this->authenticatedUser,
-			'cookies'           => $this->cookies,
-			'responseTime'      => $this->responseTime,
-			'responseStatus'    => $this->responseStatus,
-			'responseDuration'  => $this->getResponseDuration(),
-			'memoryUsage'       => $this->memoryUsage,
-			'databaseQueries'   => $this->databaseQueries,
-			'databaseDuration'  => $this->getDatabaseDuration(),
-			'cacheQueries'      => $this->cacheQueries,
-			'cacheReads'        => $this->cacheReads,
-			'cacheHits'         => $this->cacheHits,
-			'cacheWrites'       => $this->cacheWrites,
-			'cacheDeletes'      => $this->cacheDeletes,
-			'cacheTime'         => $this->cacheTime,
-			'redisCommands'     => $this->redisCommands,
-			'queueJobs'         => $this->queueJobs,
-			'timelineData'      => $this->timelineData,
-			'log'               => array_values($this->log),
-			'events'            => $this->events,
-			'routes'            => $this->routes,
-			'emailsData'        => $this->emailsData,
-			'viewsData'         => $this->viewsData,
-			'userData'          => array_map(function ($data) {
+			'id'                   => $this->id,
+			'version'              => $this->version,
+			'time'                 => $this->time,
+			'method'               => $this->method,
+			'url'                  => $this->url,
+			'uri'                  => $this->uri,
+			'headers'              => $this->headers,
+			'controller'           => $this->controller,
+			'getData'              => $this->getData,
+			'postData'             => $this->postData,
+			'requestData'          => $this->requestData,
+			'sessionData'          => $this->sessionData,
+			'authenticatedUser'    => $this->authenticatedUser,
+			'cookies'              => $this->cookies,
+			'responseTime'         => $this->responseTime,
+			'responseStatus'       => $this->responseStatus,
+			'responseDuration'     => $this->getResponseDuration(),
+			'memoryUsage'          => $this->memoryUsage,
+			'databaseQueries'      => $this->databaseQueries,
+			'databaseQueriesCount' => $this->databaseQueriesCount,
+			'databaseSlowQueries'  => $this->databaseSlowQueries,
+			'databaseSelects'      => $this->databaseSelects,
+			'databaseInserts'      => $this->databaseInserts,
+			'databaseUpdates'      => $this->databaseUpdates,
+			'databaseDeletes'      => $this->databaseDeletes,
+			'databaseOthers'       => $this->databaseOthers,
+			'databaseDuration'     => $this->getDatabaseDuration(),
+			'cacheQueries'         => $this->cacheQueries,
+			'cacheReads'           => $this->cacheReads,
+			'cacheHits'            => $this->cacheHits,
+			'cacheWrites'          => $this->cacheWrites,
+			'cacheDeletes'         => $this->cacheDeletes,
+			'cacheTime'            => $this->cacheTime,
+			'redisCommands'        => $this->redisCommands,
+			'queueJobs'            => $this->queueJobs,
+			'timelineData'         => $this->timelineData,
+			'log'                  => array_values($this->log),
+			'events'               => $this->events,
+			'routes'               => $this->routes,
+			'emailsData'           => $this->emailsData,
+			'viewsData'            => $this->viewsData,
+			'userData'             => array_map(function ($data) {
 				return $data instanceof UserData ? $data->toArray() : $data;
 			}, $this->userData),
-			'subrequests'       => $this->subrequests,
-			'xdebug'            => $this->xdebug
+			'subrequests'          => $this->subrequests,
+			'xdebug'               => $this->xdebug
 		];
 	}
 

--- a/Clockwork/Request/Request.php
+++ b/Clockwork/Request/Request.php
@@ -267,7 +267,10 @@ class Request
 			'file'       => isset($data['file']) ? $data['file'] : null,
 			'line'       => isset($data['line']) ? $data['line'] : null,
 			'trace'      => isset($data['trace']) ? $data['trace'] : null,
-			'model'      => isset($data['model']) ? $data['model'] : null
+			'model'      => isset($data['model']) ? $data['model'] : null,
+			'tags'       => array_merge(
+				isset($data['tags']) ? $data['tags'] : [], isset($data['slow']) ? [ 'slow' ] : []
+			)
 		];
 	}
 

--- a/Clockwork/Storage/SqlStorage.php
+++ b/Clockwork/Storage/SqlStorage.php
@@ -23,9 +23,10 @@ class SqlStorage extends Storage
 	protected $fields = [
 		'id', 'version', 'time', 'method', 'url', 'uri', 'headers', 'controller', 'getData', 'postData', 'requestData',
 		'sessionData', 'authenticatedUser', 'cookies', 'responseTime', 'responseStatus', 'responseDuration',
-		'memoryUsage', 'databaseQueries', 'databaseDuration', 'cacheQueries', 'cacheReads', 'cacheHits', 'cacheWrites',
-		'cacheDeletes', 'cacheTime', 'redisCommands', 'queueJobs', 'timelineData', 'log', 'events', 'routes',
-		'emailsData', 'viewsData', 'userData', 'subrequests', 'xdebug'
+		'memoryUsage', 'databaseQueries', 'databaseQueriesCount', 'databaseSlowQueries', 'databaseSelects',
+		'databaseInserts', 'databaseUpdates', 'databaseDeletes', 'databaseOthers', 'databaseDuration', 'cacheQueries',
+		'cacheReads', 'cacheHits', 'cacheWrites', 'cacheDeletes', 'cacheTime', 'redisCommands', 'queueJobs',
+		'timelineData', 'log', 'events', 'routes', 'emailsData', 'viewsData', 'userData', 'subrequests', 'xdebug'
 	];
 
 	// List of Request keys that need to be serialized before they can be stored in database
@@ -161,6 +162,13 @@ class SqlStorage extends Storage
 				$this->quote('responseDuration') . ' DOUBLE PRECISION NULL, ' .
 				$this->quote('memoryUsage') . ' DOUBLE PRECISION NULL, ' .
 				$this->quote('databaseQueries') . " {$textType} NULL, " .
+				$this->quote('databaseQueriesCount') . ' INTEGER NULL, ' .
+				$this->quote('databaseSlowQueries') . ' INTEGER NULL, ' .
+				$this->quote('databaseSelects') . ' INTEGER NULL, ' .
+				$this->quote('databaseInserts') . ' INTEGER NULL, ' .
+				$this->quote('databaseUpdates') . ' INTEGER NULL, ' .
+				$this->quote('databaseDeletes') . ' INTEGER NULL, ' .
+				$this->quote('databaseOthers') . ' INTEGER NULL, ' .
 				$this->quote('databaseDuration') . ' DOUBLE PRECISION NULL, ' .
 				$this->quote('cacheQueries') . " {$textType} NULL, " .
 				$this->quote('cacheReads') . ' INTEGER NULL, ' .

--- a/Clockwork/Support/Laravel/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Laravel/ClockworkServiceProvider.php
@@ -93,7 +93,10 @@ class ClockworkServiceProvider extends ServiceProvider
 
 		$this->app->singleton('clockwork.eloquent', function ($app) {
 			return (new EloquentDataSource(
-				$app['db'], $app['events'], $app['clockwork.support']->getConfig('database_slow_query'))
+				$app['db'],
+				$app['events'],
+				$app['clockwork.support']->getConfig('database_slow_query'),
+				$app['clockwork.support']->getConfig('database_slow_only'))
 			)
 				->collectStackTraces($app['clockwork.support']->getConfig('collect_stack_traces'));
 		});

--- a/Clockwork/Support/Laravel/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Laravel/ClockworkServiceProvider.php
@@ -92,7 +92,9 @@ class ClockworkServiceProvider extends ServiceProvider
 		});
 
 		$this->app->singleton('clockwork.eloquent', function ($app) {
-			return (new EloquentDataSource($app['db'], $app['events']))
+			return (new EloquentDataSource(
+				$app['db'], $app['events'], $app['clockwork.support']->getConfig('database_slow_query'))
+			)
 				->collectStackTraces($app['clockwork.support']->getConfig('collect_stack_traces'));
 		});
 

--- a/Clockwork/Support/Laravel/config/clockwork.php
+++ b/Clockwork/Support/Laravel/config/clockwork.php
@@ -183,7 +183,18 @@ return [
 	|
 	*/
 
-	'database_slow_query' => env('CLOCKWORK_DATABASE_SLOW_QUERY_THRESHOLD'),
+	'database_slow_query' => env('CLOCKWORK_DATABASE_SLOW_QUERY'),
+
+	/*
+	|--------------------------------------------------------------------------
+	| Database slow queries only
+	|--------------------------------------------------------------------------
+	|
+	| Collect only slow queries, with execution time over threshold configured above.
+	|
+	*/
+
+	'database_slow_only' => env('CLOCKWORK_DATABASE_SLOW_ONLY', false),
 
 	/*
 	|--------------------------------------------------------------------------

--- a/Clockwork/Support/Laravel/config/clockwork.php
+++ b/Clockwork/Support/Laravel/config/clockwork.php
@@ -175,6 +175,18 @@ return [
 
 	/*
 	|--------------------------------------------------------------------------
+	| Database slow query threshold (ms)
+	|--------------------------------------------------------------------------
+	|
+	| Query execution time threshold after which the query will be marked as slow.
+	| Marked in the "database" tab, performance log and counted as a warning.
+	|
+	*/
+
+	'database_slow_query' => env('CLOCKWORK_DATABASE_SLOW_QUERY_THRESHOLD'),
+
+	/*
+	|--------------------------------------------------------------------------
 	| Ignored events
 	|--------------------------------------------------------------------------
 	|

--- a/Clockwork/Support/Lumen/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Lumen/ClockworkServiceProvider.php
@@ -101,7 +101,13 @@ class ClockworkServiceProvider extends ServiceProvider
 		});
 
 		$this->app->singleton('clockwork.eloquent', function ($app) {
-			return new EloquentDataSource($app['db'], $app['events']);
+			return (new EloquentDataSource(
+				$app['db'],
+				$app['events'],
+				$app['clockwork.support']->getConfig('database_slow_query'),
+				$app['clockwork.support']->getConfig('database_slow_only'))
+			)
+				->collectStackTraces($app['clockwork.support']->getConfig('collect_stack_traces'));
 		});
 
 		$this->app->singleton('clockwork.cache', function ($app) {


### PR DESCRIPTION
- added marking queries as "slow" if over configured threshold
- added option to collect only show queries
- added database query counters for each query type (independent from the collected queries)
  - this is useful if you don't want to log all queries, but still want to know how many queries have been executed (eg. if the new option to collect only slow queries is enabled you will still see total amount of queries executed)
- added ability to filter queries by custom filter closures
- app PR https://github.com/underground-works/clockwork-app/pull/4