### PR TITLE
Detecting duplicate (N+1) queries in Eloquent

### DIFF
--- a/Clockwork/DataSource/Concerns/EloquentDetectDuplicateQueries.php
+++ b/Clockwork/DataSource/Concerns/EloquentDetectDuplicateQueries.php
@@ -6,6 +6,8 @@ use Clockwork\Request\Request;
 
 use Psr\Log\LogLevel;
 
+// Duplicate (N+1) queries detection for EloquentDataSource, inspired by the beyondcode/laravel-query-detector package
+// by Marcel Pociot (https://github.com/beyondcode/laravel-query-detector)
 trait EloquentDetectDuplicateQueries
 {
 	protected $duplicateQueries = [];

--- a/Clockwork/DataSource/Concerns/EloquentDetectDuplicateQueries.php
+++ b/Clockwork/DataSource/Concerns/EloquentDetectDuplicateQueries.php
@@ -1,0 +1,62 @@
+<?php namespace Clockwork\DataSource\Concerns;
+
+use Clockwork\Helpers\StackTrace;
+use Clockwork\Request\Log;
+use Clockwork\Request\Request;
+
+use Psr\Log\LogLevel;
+
+trait EloquentDetectDuplicateQueries
+{
+	protected $duplicateQueries = [];
+
+	protected function appendDuplicateQueriesWarnings(Request $request)
+	{
+		$log = new Log;
+
+		foreach ($this->duplicateQueries as $query) {
+			if ($query['count'] < 1) continue;
+
+			$log->log(
+				LogLevel::WARNING,
+				"N+1 queries: {$query['model']}::{$query['relation']} loaded {$query['count']} times.",
+				[ 'performance' => true, 'trace' => $query['trace'] ]
+			);
+		}
+
+		$request->log = array_merge($request->log, $log->toArray());
+	}
+
+	protected function detectDuplicateQuery(StackTrace $trace)
+	{
+		$relationFrame = $trace->first(function ($frame) {
+			return $frame->function == 'getRelationValue'
+				|| $frame->class == \Illuminate\Database\Eloquent\Relations\Relation::class;
+		});
+
+		if (! $relationFrame) return;
+
+		if ($relationFrame->class == \Illuminate\Database\Eloquent\Relations\Relation::class) {
+			$model = get_class($relationFrame->object->getParent());
+			$relation = get_class($relationFrame->object->getRelated());
+		} else {
+			$model = get_class($relationFrame->object);
+			$relation = $relationFrame->args[0];
+		}
+
+		$trace = $trace->skip()->limit();
+
+		$hash = implode('-', [ $model, $relation, $trace->first()->file, $trace->first()->line ]);
+
+		if (! isset($this->duplicateQueries[$hash])) {
+			$this->duplicateQueries[$hash] = [
+				'count'    => 0,
+				'model'    => $model,
+				'relation' => $relation,
+				'trace'    => $trace
+			];
+		}
+
+		$this->duplicateQueries[$hash]['count']++;
+	}
+}

--- a/Clockwork/Helpers/StackTrace.php
+++ b/Clockwork/Helpers/StackTrace.php
@@ -18,14 +18,15 @@ class StackTrace
 
 	public static function get($options = [])
 	{
-		return static::from(
-			debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS)
-		);
+		$backtraceOptions = isset($options['arguments'])
+			? DEBUG_BACKTRACE_PROVIDE_OBJECT : DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS;
+
+		return static::from(debug_backtrace($backtraceOptions), $options);
 	}
 
-	public static function raw()
+	public static function raw($options = [])
 	{
-		return static::get([ 'raw' => true ]);
+		return static::get(array_merge($options, [ 'raw' => true ]));
 	}
 
 	public static function from(array $trace, $options = [])
@@ -76,23 +77,27 @@ class StackTrace
 		}
 	}
 
-	public function filter($filter)
+	public function filter($filter = null)
 	{
+		if (! $filter) $filter = self::$defaults['filter'];
 		if ($filter instanceof StackFilter) $filter = $filter->closure();
 
 		return $this->copy(array_filter($filter, $this->frames));
 	}
 
-	public function skip($count)
+	public function skip($count = null)
 	{
+		if (! $count) $count = self::$defaults['skip'];
 		if ($count instanceof StackFilter) $count = $count->closure();
 		if ($count instanceof \Closure) $count = array_search($this->first($count), $this->frames);
 
 		return $this->copy(array_slice($this->frames, $count));
 	}
 
-	public function limit($count)
+	public function limit($count = null)
 	{
+		if (! $count) $count = self::$defaults['limit'];
+
 		return $this->copy(array_slice($this->frames, 0, $count));
 	}
 

--- a/Clockwork/Request/Log.php
+++ b/Clockwork/Request/Log.php
@@ -23,7 +23,8 @@ class Log extends AbstractLogger
 	 */
 	public function log($level = LogLevel::INFO, $message, array $context = [])
 	{
-		$trace = StackTrace::get()->resolveViewName();
+		$trace = isset($context['trace']) && $context['trace'] instanceof StackTrace
+			? $context['trace'] : StackTrace::get()->resolveViewName();
 
 		$this->data[] = [
 			'message'   => (new Serializer([ 'toString' => true ]))->normalize($message),

--- a/Clockwork/Support/Laravel/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Laravel/ClockworkServiceProvider.php
@@ -136,7 +136,8 @@ class ClockworkServiceProvider extends ServiceProvider
 				$app['events'],
 				$app['clockwork.support']->getConfig('features.database.collect_queries'),
 				$app['clockwork.support']->getConfig('features.database.slow_threshold'),
-				$app['clockwork.support']->getConfig('features.database.slow_only')
+				$app['clockwork.support']->getConfig('features.database.slow_only'),
+				$app['clockwork.support']->getConfig('features.database.detect_duplicate_queries')
 			));
 		});
 

--- a/Clockwork/Support/Laravel/config/clockwork.php
+++ b/Clockwork/Support/Laravel/config/clockwork.php
@@ -50,6 +50,9 @@ return [
 
 			// Collect only slow database queries
 			'slow_only' => env('CLOCKWORK_DATABASE_SLOW_ONLY', false),
+
+			// Detect and report duplicate (N+1) queries
+			'detect_duplicate_queries' => env('CLOCKWORK_DATABASE_DETECT_DUPLICATE_QUERIES', false)
 		],
 
 		// Sent emails


### PR DESCRIPTION
- added support for detecting duplicate (N+1) queries in EloquentDataSource
- detection is disabled by default
- StackTrace now supports collecting traces with arguments and manually applying defaults
- Log now supports passing StackTrace as "trace" key in the context
- inspired by beyondcode/laravel-query-detector (https://github.com/beyondcode/laravel-query-detector)

<img width="1324" alt="Screenshot 2019-04-03 at 23 14 17" src="https://user-images.githubusercontent.com/821582/55513560-46716400-5666-11e9-8e06-896ba89bd614.png">
