### PR TITLE
Searchable requests history

### DIFF
--- a/Clockwork/Request/Request.php
+++ b/Clockwork/Request/Request.php
@@ -78,6 +78,9 @@ class Request
 	 */
 	public $responseTime;
 
+	// Response processing time
+	public $responseDuration;
+
 	/**
 	 * Response status code
 	 */
@@ -234,7 +237,7 @@ class Request
 			'cookies'              => $this->cookies,
 			'responseTime'         => $this->responseTime,
 			'responseStatus'       => $this->responseStatus,
-			'responseDuration'     => $this->getResponseDuration(),
+			'responseDuration'     => $this->responseDuration ?: $this->getResponseDuration(),
 			'memoryUsage'          => $this->memoryUsage,
 			'databaseQueries'      => $this->databaseQueries,
 			'databaseQueriesCount' => $this->databaseQueriesCount,

--- a/Clockwork/Storage/FileStorage.php
+++ b/Clockwork/Storage/FileStorage.php
@@ -132,7 +132,7 @@ class FileStorage extends Storage
 		$found = [];
 
 		while ($request = $this->readIndex($direction)) {
-			if ($search && $search->matches($request)) $found[] = $this->loadRequest($request->id);
+			if (! $search || $search->matches($request)) $found[] = $this->loadRequest($request->id);
 			if (count($found) == $count) return $found;
 		}
 
@@ -187,10 +187,7 @@ class FileStorage extends Storage
 			if ($newline !== false && $line) break;
 		}
 
-		return new Request(array_combine(
-			[ 'id', 'time', 'method', 'uri', 'controller', 'responseStatus', 'responseDuration' ],
-			str_getcsv($line)
-		));
+		return $this->makeRequestFromIndex(str_getcsv($line));
 	}
 
 	// Read next line from index
@@ -208,9 +205,13 @@ class FileStorage extends Storage
 		// Reset the file pointer to the start of the read line
 		fseek($this->indexHandle, ftell($this->indexHandle) - strlen($line));
 
+		return $this->makeRequestFromIndex(str_getcsv($line));
+	}
+
+	protected function makeRequestFromIndex($record)
+	{
 		return new Request(array_combine(
-			[ 'id', 'time', 'method', 'uri', 'controller', 'responseStatus', 'responseDuration' ],
-			str_getcsv($line)
+			[ 'id', 'time', 'method', 'uri', 'controller', 'responseStatus', 'responseDuration' ], $record
 		));
 	}
 

--- a/Clockwork/Storage/Search.php
+++ b/Clockwork/Storage/Search.php
@@ -1,0 +1,100 @@
+<?php namespace Clockwork\Storage;
+
+use Clockwork\Request\Request;
+
+class Search
+{
+	public $uri = [];
+	public $controller = [];
+	public $method = [];
+	public $status = [];
+	public $time = [];
+	public $received = [];
+
+	public function __construct($search = [])
+	{
+		foreach ([ 'uri', 'controller', 'method', 'status', 'time', 'received' ] as $condition) {
+			$this->$condition = isset($search[$condition]) ? $search[$condition] : [];
+		}
+
+		$this->method = array_map('strtolower', $this->method);
+	}
+
+	public static function fromRequest($data = [])
+	{
+		return new static($data);
+	}
+
+	public function matches(Request $request)
+	{
+		return $this->matchesString($this->uri, $request->uri)
+			&& $this->matchesString($this->controller, $request->controller)
+			&& $this->matchesExact($this->method, strtolower($request->method))
+			&& $this->matchesNumber($this->status, $request->responseStatus)
+			&& $this->matchesNumber($this->time, $request->responseDuration)
+			&& $this->matchesDate($this->received, $request->time);
+	}
+
+	public function empty()
+	{
+		return ! count($this->uri) && ! count($this->controller) && ! count($this->method) && ! count($this->status)
+			&& ! count($this->time) && ! count($this->received);
+	}
+
+	public function notEmpty()
+	{
+		return ! $this->empty();
+	}
+
+	protected function matchesDate($inputs, $value)
+	{
+		if (! count($inputs)) return true;
+
+		foreach ($inputs as $input) {
+			if (preg_match('/^<(.+)$/', $input, $match)) {
+				if ($value < strtotime($match[1])) return true;
+			} elseif (preg_match('/^>(.+)$/', $input, $match)) {
+				if ($value > strtotime($match[1])) return true;
+			}
+		}
+
+		return false;
+	}
+
+	protected function matchesExact($inputs, $value)
+	{
+		if (! count($inputs)) return true;
+
+		return in_array($value, $inputs);
+	}
+
+	protected function matchesNumber($inputs, $value)
+	{
+		if (! count($inputs)) return true;
+
+		foreach ($inputs as $input) {
+			if (preg_match('/^<(\d+(?:\.\d+)?)$/', $input, $match)) {
+				if ($value < $match[1]) return true;
+			} elseif (preg_match('/^>(\d+(?:\.\d+)?)$/', $input, $match)) {
+				if ($value > $match[1]) return true;
+			} elseif (preg_match('/^(\d+(?:\.\d+)?)-(\d+(?:\.\d+)?)$/', $input, $match)) {
+				if ($match[1] < $value && $value < $match[2]) return true;
+			} else {
+				if ($value == $input) return true;
+			}
+		}
+
+		return false;
+	}
+
+	protected function matchesString($inputs, $value)
+	{
+		if (! count($inputs)) return true;
+
+		foreach ($inputs as $input) {
+			if (strpos($value, $input) !== false) return true;
+		}
+
+		return false;
+	}
+}

--- a/Clockwork/Storage/SqlSearch.php
+++ b/Clockwork/Storage/SqlSearch.php
@@ -1,0 +1,129 @@
+<?php namespace Clockwork\Storage;
+
+use Clockwork\Request\Request;
+
+class SqlSearch extends Search
+{
+	public $query;
+	public $bindings;
+
+	protected $conditions;
+
+	public function __construct($search = [])
+	{
+		parent::__construct($search);
+
+		list($this->conditions, $this->bindings) = $this->resolveConditions();
+
+		$this->buildQuery();
+	}
+
+	public static function fromBase(Search $search)
+	{
+		return new static((array) $search);
+	}
+
+	public function addCondition($condition, $bindings = [])
+	{
+		$this->conditions = array_merge([ $condition ], $this->conditions);
+		$this->bindings = array_merge($bindings, $this->bindings);
+		$this->buildQuery();
+
+		return $this;
+	}
+
+	protected function resolveConditions()
+	{
+		if ($this->empty()) return [ [], [] ];
+
+		$conditions = array_filter([
+			$this->resolveStringCondition('uri', $this->uri),
+			$this->resolveStringCondition('controller', $this->controller),
+			$this->resolveExactCondition('method', $this->method),
+			$this->resolveNumberCondition('responseStatus', $this->status),
+			$this->resolveNumberCondition('responseDuration', $this->time),
+			$this->resolveDateCondition('time', $this->received)
+		]);
+
+		$sql = array_map(function ($condition) { return $condition[0]; }, $conditions);
+		$bindings = array_reduce($conditions, function ($bindings, $condition) {
+			return array_merge($bindings, $condition[1]);
+		}, []);
+
+		return [ $sql, $bindings ];
+	}
+
+	protected function resolveDateCondition($field, $inputs)
+	{
+		if (! count($inputs)) return null;
+
+		$bindings = [];
+		$conditions = implode(' OR ', array_map(function ($input, $index) use ($field, &$bindings) {
+			if (preg_match('/^<(.+)$/', $input, $match)) {
+				$bindings["{$field}{$index}"] = $match[1];
+				return "{$field} < :{$field}{$index}";
+			} elseif (preg_match('/^>(.+)$/', $input, $match)) {
+				$bindings["{$field}{$index}"] = $match[1];
+				return "{$field} > :{$field}{$index}";
+			}
+		}, $inputs, array_keys($inputs)));
+
+		return [ "({$conditions})", $bindings ];
+	}
+
+	protected function resolveExactCondition($field, $inputs)
+	{
+		if (! count($inputs)) return null;
+
+		$bindings = [];
+		$values = implode(', ', array_map(function ($input, $index) use ($field, &$bindings) {
+			$bindings["{$field}{$index}"] = $input;
+			return ":{$field}{$index}";
+		}, $inputs, array_keys($inputs)));
+
+		return [ "{$field} IN ({$values})", $bindings ];
+	}
+
+	protected function resolveNumberCondition($field, $inputs)
+	{
+		if (! count($inputs)) return null;
+
+		$bindings = [];
+		$conditions = implode(' OR ', array_map(function ($input, $index) use ($field, &$bindings) {
+			if (preg_match('/^<(\d+(?:\.\d+)?)$/', $input, $match)) {
+				$bindings["{$field}{$index}"] = $match[1];
+				return "{$field} < :{$field}{$index}";
+			} elseif (preg_match('/^>(\d+(?:\.\d+)?)$/', $input, $match)) {
+				$bindings["{$field}{$index}"] = $match[1];
+				return "{$field} > :{$field}{$index}";
+			} elseif (preg_match('/^(\d+(?:\.\d+)?)-(\d+(?:\.\d+)?)$/', $input, $match)) {
+				$bindings["{$field}{$index}from"] = $match[1];
+				$bindings["{$field}{$index}to"] = $match[2];
+				return "({$field} > :{$field}{$index}from AND {$field} < :{$field}{$index}to)";
+			} else {
+				$bindings["{$field}{$index}"] = $input;
+				return "{$field} = :{$field}{$index}";
+			}
+		}, $inputs, array_keys($inputs)));
+
+		return [ "({$conditions})", $bindings ];
+	}
+
+	protected function resolveStringCondition($field, $inputs)
+	{
+		if (! count($inputs)) return null;
+
+		$bindings = [];
+		$conditions = implode(' OR ', array_map(function ($input, $index) use ($field, &$bindings) {
+			$bindings["{$field}{$index}"] = $input;
+			return "{$field} LIKE :{$field}{$index}";
+		}, $inputs, array_keys($inputs)));
+
+		return [ "({$conditions})", $bindings ];
+	}
+
+	protected function buildQuery()
+	{
+		$this->query = count($this->conditions) ? 'WHERE ' . implode(' AND ', $this->conditions) : '';
+	}
+}

--- a/Clockwork/Storage/StorageInterface.php
+++ b/Clockwork/Storage/StorageInterface.php
@@ -8,19 +8,19 @@ use Clockwork\Request\Request;
 interface StorageInterface
 {
 	// Returns all requests
-	public function all();
+	public function all(Search $search = null);
 
 	// Return a single request by id
 	public function find($id);
 
 	// Return the latest request
-	public function latest();
+	public function latest(Search $search = null);
 
 	// Return requests received before specified id, optionally limited to specified count
-	public function previous($id, $count = null);
+	public function previous($id, $count = null, Search $search = null);
 
 	// Return requests received after specified id, optionally limited to specified count
-	public function next($id, $count = null);
+	public function next($id, $count = null, Search $search = null);
 
 	// Store request
 	public function store(Request $request);

--- a/Clockwork/Support/Laravel/ClockworkSupport.php
+++ b/Clockwork/Support/Laravel/ClockworkSupport.php
@@ -83,7 +83,7 @@ class ClockworkSupport
 			$storage = new SqlStorage($database, $table, null, null, $expiration);
 		} else {
 			$storage = new FileStorage(
-				$this->getConfig('storage_files_path', storage_path('clockwork')), 0700, $expiration
+				$this->getConfig('storage_files_path', storage_path('clockwork')), 0700, $expiration, storage_path('clockwork/index')
 			);
 		}
 

--- a/Clockwork/Support/Laravel/ClockworkSupport.php
+++ b/Clockwork/Support/Laravel/ClockworkSupport.php
@@ -8,6 +8,7 @@ use Clockwork\Helpers\ServerTiming;
 use Clockwork\Helpers\StackFilter;
 use Clockwork\Helpers\StackTrace;
 use Clockwork\Storage\FileStorage;
+use Clockwork\Storage\Search;
 use Clockwork\Storage\SqlStorage;
 use Clockwork\Web\Web;
 
@@ -44,11 +45,11 @@ class ClockworkSupport
 		}
 
 		if ($direction == 'previous') {
-			$data = $storage->previous($id, $count);
+			$data = $storage->previous($id, $count, Search::fromRequest($this->app['request']->all()));
 		} elseif ($direction == 'next') {
-			$data = $storage->next($id, $count);
+			$data = $storage->next($id, $count, Search::fromRequest($this->app['request']->all()));
 		} elseif ($id == 'latest') {
-			$data = $storage->latest();
+			$data = $storage->latest(Search::fromRequest($this->app['request']->all()));
 		} else {
 			$data = $storage->find($id);
 		}

--- a/Clockwork/Support/Laravel/ClockworkSupport.php
+++ b/Clockwork/Support/Laravel/ClockworkSupport.php
@@ -83,7 +83,7 @@ class ClockworkSupport
 			$storage = new SqlStorage($database, $table, null, null, $expiration);
 		} else {
 			$storage = new FileStorage(
-				$this->getConfig('storage_files_path', storage_path('clockwork')), 0700, $expiration, storage_path('clockwork/index')
+				$this->getConfig('storage_files_path', storage_path('clockwork')), 0700, $expiration
 			);
 		}
 

--- a/Clockwork/Support/Symfony/ClockworkFactory.php
+++ b/Clockwork/Support/Symfony/ClockworkFactory.php
@@ -26,7 +26,9 @@ class ClockworkFactory
 
 	public function clockworkStorage()
 	{
-		return new SymfonyStorage($this->container->get('profiler'));
+		return new SymfonyStorage(
+			$this->container->get('profiler'), substr($this->container->getParameter('profiler.storage.dsn'), 5)
+		);
 	}
 
 	public function clockworkSupport($config)

--- a/Clockwork/Support/Symfony/ClockworkSupport.php
+++ b/Clockwork/Support/Symfony/ClockworkSupport.php
@@ -2,6 +2,7 @@
 
 use Clockwork\Authentication\NullAuthenticator;
 use Clockwork\Authentication\SimpleAuthenticator;
+use Clockwork\Storage\Search;
 use Clockwork\Web\Web;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -38,11 +39,11 @@ class ClockworkSupport
 		}
 
 		if ($direction == 'previous') {
-			$data = $storage->previous($id, $count);
+			$data = $storage->previous($id, $count, Search::fromRequest($request->query->all()));
 		} elseif ($direction == 'next') {
-			$data = $storage->next($id, $count);
+			$data = $storage->next($id, $count, Search::fromRequest($request->query->all()));
 		} elseif ($id == 'latest') {
-			$data = $storage->latest();
+			$data = $storage->latest(Search::fromRequest($request->query->all()));
 		} else {
 			$data = $storage->find($id);
 		}
@@ -51,7 +52,7 @@ class ClockworkSupport
 			? array_map(function ($request) { return $request->toArray(); }, $data)
 			: $data->toArray();
 
-		return (new JsonResponse)->setData($data);
+		return new JsonResponse($data);
 	}
 
 	public function getWebAsset($path)


### PR DESCRIPTION
- added support for searchable requests history implemented in the storage api
- extended the `StorageInterface` api using a new `Search` class able to specify common parameters for the search
- implemented the new search api in both `FileStorage` and `SqlStorage`
- rewrote `FileStorage` based on a simple csv formatted index file
- rewrote `SymfonyStorage` to work with reworked `FileStorage` and support limited search (method, uri, time, status)
- supported in all integrations except Slim
- app PR https://github.com/underground-works/clockwork-app/pull/6

<img width="1318" alt="Screenshot 2019-04-08 at 02 29 58" src="https://user-images.githubusercontent.com/821582/55692240-3d55ff00-59a6-11e9-8e8b-834ab26ddb98.png">
