### PR TITLE
Ability to compress metadata files

### DIFF
--- a/Clockwork/Support/Laravel/ClockworkSupport.php
+++ b/Clockwork/Support/Laravel/ClockworkSupport.php
@@ -83,7 +83,10 @@ class ClockworkSupport
 			$storage = new SqlStorage($database, $table, null, null, $expiration);
 		} else {
 			$storage = new FileStorage(
-				$this->getConfig('storage_files_path', storage_path('clockwork')), 0700, $expiration
+				$this->getConfig('storage_files_path', storage_path('clockwork')),
+				0700,
+				$expiration,
+				$this->getConfig('storage_files_compress', false)
 			);
 		}
 

--- a/Clockwork/Support/Laravel/config/clockwork.php
+++ b/Clockwork/Support/Laravel/config/clockwork.php
@@ -146,6 +146,9 @@ return [
 
 	'storage_files_path' => env('CLOCKWORK_STORAGE_FILES_PATH', storage_path('clockwork')),
 
+	// Compress the metadata files using gzip, trading a little bit of performance for lower disk usage
+	'storage_files_compress' => env('CLOCKWORK_STORAGE_FILES_COMPRESS', false),
+
 	'storage_sql_database' => env('CLOCKWORK_STORAGE_SQL_DATABASE', storage_path('clockwork.sqlite')),
 	'storage_sql_table'    => env('CLOCKWORK_STORAGE_SQL_TABLE', 'clockwork'),
 

--- a/Clockwork/Support/Vanilla/Clockwork.php
+++ b/Clockwork/Support/Vanilla/Clockwork.php
@@ -146,7 +146,10 @@ class Clockwork
 			);
 		} else {
 			$storage = new FileStorage(
-				$this->config['storage_files_path'], 0700, $this->config['storage_expiration']
+				$this->config['storage_files_path'],
+				0700,
+				$this->config['storage_expiration'],
+				$this->config['storage_files_compress']
 			);
 		}
 

--- a/Clockwork/Support/Vanilla/config.php
+++ b/Clockwork/Support/Vanilla/config.php
@@ -61,6 +61,9 @@ return [
 
 	'storage_files_path' => isset($_ENV['CLOCKWORK_STORAGE_FILES_PATH']) ? $_ENV['CLOCKWORK_STORAGE_FILES_PATH'] : __DIR__ . '/../../../../../clockwork',
 
+	// Compress the metadata files using gzip, trading a little bit of performance for lower disk usage
+	'storage_files_compress' => isset($_ENV['CLOCKWORK_STORAGE_FILES_COMPRESS']) ? $_ENV['CLOCKWORK_STORAGE_FILES_COMPRESS'] : false,
+
 	'storage_sql_database' => isset($_ENV['CLOCKWORK_STORAGE_SQL_DATABASE']) ? $_ENV['CLOCKWORK_STORAGE_SQL_DATABASE'] : 'sqlite:' . __DIR__ . '/../../../../../clockwork.sqlite',
 	'storage_sql_username' => isset($_ENV['CLOCKWORK_STORAGE_SQL_USERNAME']) ? $_ENV['CLOCKWORK_STORAGE_SQL_USERNAME'] : null,
 	'storage_sql_password' => isset($_ENV['CLOCKWORK_STORAGE_SQL_PASSWORD']) ? $_ENV['CLOCKWORK_STORAGE_SQL_PASSWORD'] : null,


### PR DESCRIPTION
- added ability to compress metadata files when using `FilesStorage` (disabled by default)
- compressed by gzip w/ default compression level (requires PHP built with zlib)
- little to no overhead when saving metadata, huge disk space savings with large metadata

**benchmark results**
- 50 requests to an endpoint generating large amount of metadata
   - without compression - 78M metadata size, 80.67 secs
   - with compression - 1.9M metadata size, 82.95 secs