### PR TITLE
Collect executed middleware

### DIFF
--- a/Clockwork/DataSource/LaravelDataSource.php
+++ b/Clockwork/DataSource/LaravelDataSource.php
@@ -73,6 +73,7 @@ class LaravelDataSource extends DataSource
 		$request->controller     = $this->getController();
 		$request->headers        = $this->getRequestHeaders();
 		$request->responseStatus = $this->getResponseStatus();
+		$request->middleware     = $this->getMiddleware();
 		$request->routes         = $this->getRoutes();
 		$request->sessionData    = $this->getSessionData();
 
@@ -231,6 +232,16 @@ class LaravelDataSource extends DataSource
 	protected function getResponseStatus()
 	{
 		return $this->response->getStatusCode();
+	}
+
+	// Return array of middleware for the matched route
+	protected function getMiddleware()
+	{
+		$route = $this->app['router']->current();
+
+		if (! $route) return;
+
+		return method_exists($route, 'gatherMiddleware') ? $route->gatherMiddleware() : $route->middleware();
 	}
 
 	/**

--- a/Clockwork/Request/Request.php
+++ b/Clockwork/Request/Request.php
@@ -89,6 +89,9 @@ class Request
 	// Peak memory usage in bytes
 	public $memoryUsage;
 
+	// Executed middleware
+	public $middleware = [];
+
 	/**
 	 * Database queries array
 	 */
@@ -239,6 +242,7 @@ class Request
 			'responseStatus'       => $this->responseStatus,
 			'responseDuration'     => $this->responseDuration ?: $this->getResponseDuration(),
 			'memoryUsage'          => $this->memoryUsage,
+			'middleware'           => $this->middleware,
 			'databaseQueries'      => $this->databaseQueries,
 			'databaseQueriesCount' => $this->databaseQueriesCount,
 			'databaseSlowQueries'  => $this->databaseSlowQueries,

--- a/Clockwork/Storage/SqlStorage.php
+++ b/Clockwork/Storage/SqlStorage.php
@@ -39,6 +39,7 @@ class SqlStorage extends Storage
 		'responseStatus'       => 'INTEGER NULL',
 		'responseDuration'     => 'DOUBLE PRECISION NULL',
 		'memoryUsage'          => 'DOUBLE PRECISION NULL',
+		'middleware'           => 'TEXT NULL',
 		'databaseQueries'      => 'TEXT NULL',
 		'databaseQueriesCount' => 'INTEGER NULL',
 		'databaseSlowQueries'  => 'INTEGER NULL',


### PR DESCRIPTION
- only supported in Laravel atm
- collects middleware names and groups, eg. "web", "auth:admin" etc.
- it's also possible to collect all middleware classes in Laravel instead, might make it a setting in future
- app PR https://github.com/underground-works/clockwork-app/pull/9