### PR TITLE
fix cleanup [--all] command

### DIFF
--- a/Clockwork/Storage/FileStorage.php
+++ b/Clockwork/Storage/FileStorage.php
@@ -94,13 +94,13 @@ class FileStorage extends Storage
 	}
 
 	// Cleanup old requests
-	public function cleanup($force = false)
+	public function cleanup($force = false, $count = 1)
 	{
 		if ($this->expiration === false || (! $force && rand(1, $this->cleanupChance) != 1)) return;
 
 		$expirationTime = time() - ($this->expiration * 60);
 
-		$old = $this->searchIndexBackward(new Search([ 'time' => [ "<{$expirationTime}" ] ]));
+		$old = $this->searchIndexBackward(new Search([ 'time' => [ "<{$expirationTime}" ] ]), null, $count);
 
 		foreach ($old as $request) {
 			$path = "{$this->path}/{$request->id}.json";
@@ -144,10 +144,10 @@ class FileStorage extends Storage
 
 		while ($request = $this->readIndex($direction)) {
 			if (! $search || $search->matches($request)) $found[] = $this->loadRequest($request->id);
-			if (count($found) == $count) return $found;
+			if (count($found = array_filter($found)) === $count) return $found;
 		}
 
-		if ($count == 1) return reset($found);
+		if ($count === 1) return reset($found);
 
 		return $direction == 'next' ? $found : array_reverse($found);
 	}

--- a/Clockwork/Support/Laravel/ClockworkCleanCommand.php
+++ b/Clockwork/Support/Laravel/ClockworkCleanCommand.php
@@ -12,6 +12,8 @@ class ClockworkCleanCommand extends Command
 	// The console command description.
 	protected $description = 'Cleans Clockwork request metadata';
 
+	protected $count = 1;
+
 	public function getOptions()
 	{
 		return [
@@ -25,11 +27,13 @@ class ClockworkCleanCommand extends Command
 	{
 		if ($this->option('all')) {
 			$this->laravel['config']->set('clockwork.storage_expiration', 0);
+            $this->count = null;
 		} elseif ($expiration = $this->option('expiration')) {
 			$this->laravel['config']->set('clockwork.storage_expiration', $expiration);
+            $this->count = null;
 		}
 
-		$this->laravel['clockwork.support']->getStorage()->cleanup($force = true);
+		$this->laravel['clockwork.support']->getStorage()->cleanup($force = true, $this->count);
 
 		$this->info('Metadata cleaned successfully.');
 	}


### PR DESCRIPTION
This pull request fix the ```artisan cleanup [--all]``` command not cleaning request files in ```/storage/clockwork```.

It also makes sure, the ```$found``` array does not contains ```null```values, preventig an exception of type ```"Invalid argument supplied for foreach()"```.

```sh
# clean last request metadata
artisan clockwork:clean

# clean all requests in storage/clockwork
artisan clockwork:clean --all
```