### PR TITLE
Correct order of arguments to array_filter in StackTrace

### DIFF
--- a/Clockwork/Helpers/StackTrace.php
+++ b/Clockwork/Helpers/StackTrace.php
@@ -54,7 +54,7 @@ class StackTrace
 	{
 		if ($filter instanceof StackFilter) $filter = $filter->closure();
 
-		return $this->copy(array_filter($filter, $this->frames));
+		return $this->copy(array_filter($this->frames, $filter));
 	}
 
 	public function skip($count = null)


### PR DESCRIPTION
Nice work on the recent changes! Really digging the in-extension stack traces.

I believe this to be a small error I found while toying with Clockwork trying to filter out vendor code.