### PR TITLE
Update created .gitignore to ignore compressed files

### DIFF
--- a/Clockwork/Storage/FileStorage.php
+++ b/Clockwork/Storage/FileStorage.php
@@ -33,7 +33,7 @@ class FileStorage extends Storage
 			}
 
 			// create default .gitignore, to ignore stored json files
-			file_put_contents("{$path}/.gitignore", "*.json\nindex\n");
+			file_put_contents("{$path}/.gitignore", "*.json\n*.json.gz\nindex\n");
 		}
 
 		if (! is_writable($path)) {


### PR DESCRIPTION
After enabling `CLOCKWORK_STORAGE_FILES_COMPRESS`, I found that git was not ignoring the compressed files. This updates the creation of the `.gitignore` file to also ignore `*.json.gz` files.