### PR TITLE
Fix LaravelDataSource when auth machinery is disabled

### DIFF
--- a/Clockwork/DataSource/LaravelDataSource.php
+++ b/Clockwork/DataSource/LaravelDataSource.php
@@ -279,6 +279,7 @@ class LaravelDataSource extends DataSource
 	// Add authenticated user data to the request
 	protected function resolveAuthenticatedUser(Request $request)
 	{
+		if (! $this->app->has('auth')) return;
 		if (! ($user = $this->app['auth']->user())) return;
 		if (! isset($user->email) || ! isset($user->id)) return;
 


### PR DESCRIPTION
Hi!

With a Laravel app that has no AuthServiceProvider (certainly not the most common case, but not that exotic neither :-), the `LaravelDataSource` crashes because it assumes that the app always has a _"auth"_ service, that will have a `user()` method.

This tiny fix prevents that kind of crash.
I tried to follow the existing code style.

Oh, and while I'm there... Thank you so much for this great project, the developer experience is top notch! :heart_eyes: 