### PR TITLE
Added support for debugging tests

### DIFF
--- a/Clockwork/Clockwork.php
+++ b/Clockwork/Clockwork.php
@@ -158,6 +158,21 @@ class Clockwork implements LoggerInterface
 		return $this;
 	}
 
+	// Resolve current request as "test" type request, with test-specific metadata, accepts test name, status,
+	// status message in case of failure and array of ran asserts
+	public function resolveTest($name, $status = 'passed', $statusMessage = null, $asserts = [])
+	{
+		$this->resolveRequest();
+
+		$this->request->type = 'test';
+		$this->request->testName = $name;
+		$this->request->testStatus = $status;
+		$this->request->testStatusMessage = $statusMessage;
+		$this->request->testAsserts = $asserts;
+
+		return $this;
+	}
+
 	// Extends the request with additional data form all data sources when being shown in the Clockwork app
 	public function extendRequest(Request $request = null)
 	{

--- a/Clockwork/Clockwork.php
+++ b/Clockwork/Clockwork.php
@@ -158,13 +158,13 @@ class Clockwork implements LoggerInterface
 		return $this;
 	}
 
-	// Resolve current request as "test" type request, with test-specific metadata, accepts test name, status,
-	// status message in case of failure and array of ran asserts
-	public function resolveTest($name, $status = 'passed', $statusMessage = null, $asserts = [])
+	// Resolve the current request as a "test" type request with test-specific data, accepts test name, status, status
+	// message in case of failure and array of ran asserts
+	public function resolveAsTest($name, $status = 'passed', $statusMessage = null, $asserts = [])
 	{
 		$this->resolveRequest();
 
-		$this->request->type = 'test';
+		$this->request->type = RequestType::TEST;
 		$this->request->testName = $name;
 		$this->request->testStatus = $status;
 		$this->request->testStatusMessage = $statusMessage;

--- a/Clockwork/Clockwork.php
+++ b/Clockwork/Clockwork.php
@@ -168,7 +168,10 @@ class Clockwork implements LoggerInterface
 		$this->request->testName = $name;
 		$this->request->testStatus = $status;
 		$this->request->testStatusMessage = $statusMessage;
-		$this->request->testAsserts = $asserts;
+
+		foreach ($asserts as $assert) {
+			$this->request->addTestAssert($assert['name'], $assert['arguments'], $assert['passed'], $assert['trace']);
+		}
 
 		return $this;
 	}

--- a/Clockwork/DataSource/LaravelDataSource.php
+++ b/Clockwork/DataSource/LaravelDataSource.php
@@ -48,6 +48,9 @@ class LaravelDataSource extends DataSource
 	// Whether we should collect routes
 	protected $collectRoutes = false;
 
+	// Timestamp w/ ms precision when the class was instantiated, used as request time when testing
+	protected $creationTime;
+
 	/**
 	 * Create a new data source, takes Laravel application instance as an argument
 	 */
@@ -60,6 +63,8 @@ class LaravelDataSource extends DataSource
 
 		$this->timeline = new Timeline();
 		$this->views    = new Timeline();
+
+		$this->creationTime = microtime(true);
 	}
 
 	/**
@@ -67,6 +72,7 @@ class LaravelDataSource extends DataSource
 	 */
 	public function resolve(Request $request)
 	{
+		$request->time           = $this->getRequestTime();
 		$request->method         = $this->getRequestMethod();
 		$request->url            = $this->getRequestUrl();
 		$request->uri            = $this->getRequestUri();
@@ -199,6 +205,18 @@ class LaravelDataSource extends DataSource
 		}
 
 		return $controller;
+	}
+
+	/**
+	 * Return response time in most precise form
+	 */
+	protected function getRequestTime()
+	{
+		if ($this->app->runningUnitTests()) {
+			return $this->creationTime;
+		} elseif (isset($_SERVER['REQUEST_TIME_FLOAT'])) {
+			return $_SERVER['REQUEST_TIME_FLOAT'];
+		}
 	}
 
 	/**

--- a/Clockwork/DataSource/LaravelDataSource.php
+++ b/Clockwork/DataSource/LaravelDataSource.php
@@ -48,9 +48,6 @@ class LaravelDataSource extends DataSource
 	// Whether we should collect routes
 	protected $collectRoutes = false;
 
-	// Timestamp w/ ms precision when the class was instantiated, used as request time when testing
-	protected $creationTime;
-
 	/**
 	 * Create a new data source, takes Laravel application instance as an argument
 	 */
@@ -63,8 +60,6 @@ class LaravelDataSource extends DataSource
 
 		$this->timeline = new Timeline();
 		$this->views    = new Timeline();
-
-		$this->creationTime = microtime(true);
 	}
 
 	/**
@@ -72,7 +67,6 @@ class LaravelDataSource extends DataSource
 	 */
 	public function resolve(Request $request)
 	{
-		$request->time           = $this->getRequestTime();
 		$request->method         = $this->getRequestMethod();
 		$request->url            = $this->getRequestUrl();
 		$request->uri            = $this->getRequestUri();
@@ -205,18 +199,6 @@ class LaravelDataSource extends DataSource
 		}
 
 		return $controller;
-	}
-
-	/**
-	 * Return response time in most precise form
-	 */
-	protected function getRequestTime()
-	{
-		if ($this->app->runningUnitTests()) {
-			return $this->creationTime;
-		} elseif (isset($_SERVER['REQUEST_TIME_FLOAT'])) {
-			return $_SERVER['REQUEST_TIME_FLOAT'];
-		}
 	}
 
 	/**

--- a/Clockwork/Helpers/StackTrace.php
+++ b/Clockwork/Helpers/StackTrace.php
@@ -13,8 +13,9 @@ class StackTrace
 	{
 		$backtraceOptions = isset($options['arguments'])
 			? DEBUG_BACKTRACE_PROVIDE_OBJECT : DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS;
+		$limit = isset($options['limit']) ? $options['limit'] : 0;
 
-		return static::from(debug_backtrace($backtraceOptions));
+		return static::from(debug_backtrace($backtraceOptions, $limit));
 	}
 
 	public static function from(array $trace)
@@ -52,11 +53,22 @@ class StackTrace
 		}
 	}
 
+	public function last($filter = null)
+	{
+		if (! $filter) return $this->frames[count($this->frames) - 1];
+
+		if ($filter instanceof StackFilter) $filter = $filter->closure();
+
+		foreach (array_reverse($this->frames) as $frame) {
+			if ($filter($frame)) return $frame;
+		}
+	}
+
 	public function filter($filter = null)
 	{
 		if ($filter instanceof StackFilter) $filter = $filter->closure();
 
-		return $this->copy(array_filter($this->frames, $filter));
+		return $this->copy(array_values(array_filter($this->frames, $filter)));
 	}
 
 	public function skip($count = null)

--- a/Clockwork/Request/Request.php
+++ b/Clockwork/Request/Request.php
@@ -230,6 +230,18 @@ class Request
 	// Queue job additional options
 	public $jobOptions = [];
 
+	// Test name
+	public $testName;
+
+	// Test status
+	public $testStatus;
+
+	// Test status message (eg. in case of failure)
+	public $testStatusMessage;
+
+	// Ran test asserts
+	public $testAsserts = [];
+
 	// Parent request
 	public $parent;
 
@@ -333,6 +345,10 @@ class Request
 			'jobQueue'                 => $this->jobQueue,
 			'jobConnection'            => $this->jobConnection,
 			'jobOptions'               => $this->jobOptions,
+			'testName'                 => $this->testName,
+			'testStatus'               => $this->testStatus,
+			'testStatusMessage'        => $this->testStatusMessage,
+			'testAsserts'              => $this->testAsserts,
 			'parent'                   => $this->parent
 		];
 	}
@@ -476,6 +492,17 @@ class Request
 		$userData = (new UserData)->title($key);
 
 		return $key ? $this->userData[$key] = $userData : $this->userData[] = $userData;
+	}
+
+	// Add a ran test assert, takes the asset name, arguments, whether it passed and trace as arguments
+	public function addTestAssert($name, $arguments = null, $passed = true, $trace = null)
+	{
+		$this->testAsserts[] = [
+			'name'      => $name,
+			'arguments' => $arguments,
+			'trace'     => $trace,
+			'passed'    => $passed
+		];
 	}
 
 	/**

--- a/Clockwork/Request/Request.php
+++ b/Clockwork/Request/Request.php
@@ -499,7 +499,7 @@ class Request
 	{
 		$this->testAsserts[] = [
 			'name'      => $name,
-			'arguments' => $arguments,
+			'arguments' => (new Serializer)->normalize($arguments),
 			'trace'     => $trace,
 			'passed'    => $passed
 		];

--- a/Clockwork/Request/Request.php
+++ b/Clockwork/Request/Request.php
@@ -494,7 +494,7 @@ class Request
 		return $key ? $this->userData[$key] = $userData : $this->userData[] = $userData;
 	}
 
-	// Add a ran test assert, takes the asset name, arguments, whether it passed and trace as arguments
+	// Add a ran test assert, takes the assert name, arguments, whether it passed and trace as arguments
 	public function addTestAssert($name, $arguments = null, $passed = true, $trace = null)
 	{
 		$this->testAsserts[] = [

--- a/Clockwork/Request/RequestType.php
+++ b/Clockwork/Request/RequestType.php
@@ -6,4 +6,5 @@ class RequestType
 	const REQUEST = 'request';
 	const COMMAND = 'command';
 	const QUEUE_JOB = 'queue-job';
+	const TEST = 'test';
 }

--- a/Clockwork/Storage/FileStorage.php
+++ b/Clockwork/Storage/FileStorage.php
@@ -268,6 +268,8 @@ class FileStorage extends Storage
 			$nameField = 'commandName';
 		} elseif ($type == 'queue-job') {
 			$nameField = 'jobName';
+		} elseif ($type == 'test') {
+			$nameField = 'testName';
 		} else {
 			$nameField = 'uri';
 		}
@@ -288,6 +290,8 @@ class FileStorage extends Storage
 			$nameField = 'commandName';
 		} elseif ($request->type == 'queue-job') {
 			$nameField = 'jobName';
+		} elseif ($request->type == 'test') {
+			$nameField = 'testName';
 		} else {
 			$nameField = 'uri';
 		}

--- a/Clockwork/Storage/Search.php
+++ b/Clockwork/Storage/Search.php
@@ -34,6 +34,8 @@ class Search
 			return $this->matchesCommand($request);
 		} elseif ($request->type == RequestType::QUEUE_JOB) {
 			return $this->matchesQueueJob($request);
+		} elseif ($request->type == RequestType::TEST) {
+			return $this->matchesTest($request);
 		} else {
 			return $this->matchesRequest($request);
 		}
@@ -64,6 +66,15 @@ class Search
 		return $this->matchesString($this->type, RequestType::QUEUE_JOB)
 			&& $this->matchesString($this->name, $request->jobName)
 			&& $this->matchesString($this->status, $request->jobStatus)
+			&& $this->matchesNumber($this->time, $request->responseDuration)
+			&& $this->matchesDate($this->received, $request->time);
+	}
+
+	protected function matchesTest(Request $request)
+	{
+		return $this->matchesString($this->type, RequestType::TEST)
+			&& $this->matchesString($this->name, $request->testName)
+			&& $this->matchesString($this->status, $request->testStatus)
 			&& $this->matchesNumber($this->time, $request->responseDuration)
 			&& $this->matchesDate($this->received, $request->time);
 	}

--- a/Clockwork/Storage/SqlSearch.php
+++ b/Clockwork/Storage/SqlSearch.php
@@ -38,10 +38,10 @@ class SqlSearch extends Search
 
 		$conditions = array_filter([
 			$this->resolveStringCondition([ 'type' ], $this->type),
-			$this->resolveStringCondition([ 'uri', 'commandName', 'jobName' ], array_merge($this->uri, $this->name)),
+			$this->resolveStringCondition([ 'uri', 'commandName', 'jobName', 'testName' ], array_merge($this->uri, $this->name)),
 			$this->resolveStringCondition([ 'controller' ], $this->controller),
 			$this->resolveExactCondition([ 'method' ], $this->method),
-			$this->resolveNumberCondition([ 'responseStatus', 'commandExitCode', 'jobStatus' ], $this->status),
+			$this->resolveNumberCondition([ 'responseStatus', 'commandExitCode', 'jobStatus', 'testStatus' ], $this->status),
 			$this->resolveNumberCondition([ 'responseDuration' ], $this->time),
 			$this->resolveDateCondition([ 'time' ], $this->received)
 		]);

--- a/Clockwork/Support/Laravel/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Laravel/ClockworkServiceProvider.php
@@ -13,6 +13,7 @@ use Clockwork\DataSource\SwiftDataSource;
 use Clockwork\DataSource\XdebugDataSource;
 use Clockwork\Helpers\StackFilter;
 use Clockwork\Request\Log;
+use Clockwork\Request\Request;
 use Clockwork\Storage\StorageInterface;
 
 use Illuminate\Redis\RedisManager;
@@ -74,6 +75,7 @@ class ClockworkServiceProvider extends ServiceProvider
 			$clockwork = (new Clockwork)
 				->setAuthenticator($app['clockwork.authenticator'])
 				->setLog($app['clockwork.log'])
+				->setRequest($app['clockwork.request'])
 				->setStorage($app['clockwork.storage'])
 				->addDataSource(new PhpDataSource())
 				->addDataSource($app['clockwork.laravel']);
@@ -97,6 +99,10 @@ class ClockworkServiceProvider extends ServiceProvider
 			return new Log;
 		});
 
+		$this->app->singleton('clockwork.request', function ($app) {
+			return new Request;
+		});
+
 		$this->app->singleton('clockwork.storage', function ($app) {
 			return $app['clockwork.support']->getStorage();
 		});
@@ -109,8 +115,8 @@ class ClockworkServiceProvider extends ServiceProvider
 		$this->registerDataSources();
 		$this->registerAliases();
 
+		$this->app->make('clockwork.request'); // instantiate the request to have id and time available as early as possible
 		$this->app['clockwork.support']->configureSerializer();
-
 		$this->app['clockwork.laravel']->listenToEarlyEvents();
 
 		if ($this->app['clockwork.support']->getConfig('register_helpers', true)) {

--- a/Clockwork/Support/Laravel/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Laravel/ClockworkServiceProvider.php
@@ -153,6 +153,15 @@ class ClockworkServiceProvider extends ServiceProvider
 				}, 'early');
 			}
 
+			if ($app->runningUnitTests()) {
+				$dataSource->addFilter(function ($query, $trace) {
+					return ! $trace->first(StackFilter::make()->isClass([
+						\Illuminate\Database\Migrations\Migrator::class,
+						\Illuminate\Database\Console\Migrations\MigrateCommand::class
+					]));
+				});
+			}
+
 			return $dataSource;
 		});
 

--- a/Clockwork/Support/Laravel/ClockworkSupport.php
+++ b/Clockwork/Support/Laravel/ClockworkSupport.php
@@ -300,7 +300,7 @@ class ClockworkSupport
 	public function isCollectingRequests()
 	{
 		return ($this->isEnabled() || $this->getConfig('collect_data_always', false))
-			&& ! $this->app->runningInConsole()
+			// && ! $this->app->runningInConsole()
 			&& ! $this->isUriFiltered($this->app['request']->getRequestUri());
 	}
 

--- a/Clockwork/Support/Laravel/ClockworkSupport.php
+++ b/Clockwork/Support/Laravel/ClockworkSupport.php
@@ -280,7 +280,8 @@ class ClockworkSupport
 	{
 		return $this->isCollectingCommands()
 			|| $this->isCollectingQueueJobs()
-			|| $this->isCollectingRequests();
+			|| $this->isCollectingRequests()
+			|| $this->isCollectingTests();
 	}
 
 	public function isCollectingCommands()
@@ -300,8 +301,15 @@ class ClockworkSupport
 	public function isCollectingRequests()
 	{
 		return ($this->isEnabled() || $this->getConfig('collect_data_always', false))
-			// && ! $this->app->runningInConsole()
+			&& ! $this->app->runningInConsole()
 			&& ! $this->isUriFiltered($this->app['request']->getRequestUri());
+	}
+
+	public function isCollectingTests()
+	{
+		return ($this->isEnabled() || $this->getConfig('collect_data_always', false))
+			&& $this->app->runningInConsole()
+			&& $this->getConfig('tests.collect', false);
 	}
 
 	public function isFeatureEnabled($feature)

--- a/Clockwork/Support/Laravel/ClockworkSupport.php
+++ b/Clockwork/Support/Laravel/ClockworkSupport.php
@@ -384,6 +384,13 @@ class ClockworkSupport
 		return in_array($queueJob, $blacklist);
 	}
 
+	public function isTestFiltered($test)
+	{
+		$blacklist = $this->getConfig('tests.except', []);
+
+		return in_array($test, $blacklist);
+	}
+
 	protected function appendServerTimingHeader($response, $request)
 	{
 		if (($eventsCount = $this->getConfig('server_timing', 10)) !== false) {

--- a/Clockwork/Support/Laravel/Tests/UsesClockwork.php
+++ b/Clockwork/Support/Laravel/Tests/UsesClockwork.php
@@ -1,0 +1,87 @@
+<?php namespace Clockwork\Support\Laravel\Tests;
+
+use Clockwork\Helpers\Serializer;
+use Clockwork\Helpers\StackFilter;
+use Clockwork\Helpers\StackTrace;
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Runner\BaseTestRunner;
+
+trait UsesClockwork
+{
+	protected static $clockwork = [
+		'assertsRan' => [],
+		'testStart'  => null
+	];
+
+	protected function setUp()
+	{
+		parent::setUp();
+		$this->setUpClockwork();
+	}
+
+	protected function setUpClockwork()
+	{
+		$this->beforeApplicationDestroyed(function () {
+			$this->app->make('clockwork')
+				->resolveTest(
+					$this->toString(),
+					$this->resolveClockworkStatus(),
+					$this->getStatusMessage(),
+					$this->resolveClockworkAssertsRan()
+				)
+				->storeRequest();
+		});
+	}
+
+	protected function resolveClockworkStatus()
+	{
+		$status = $this->getStatus();
+
+		$statuses = [
+			BaseTestRunner::STATUS_UNKNOWN    => 'unknown',
+			BaseTestRunner::STATUS_PASSED     => 'passed',
+			BaseTestRunner::STATUS_SKIPPED    => 'skipped',
+			BaseTestRunner::STATUS_INCOMPLETE => 'incomplete',
+			BaseTestRunner::STATUS_FAILURE    => 'failed',
+			BaseTestRunner::STATUS_ERROR      => 'error',
+			BaseTestRunner::STATUS_RISKY      => 'passed',
+			BaseTestRunner::STATUS_WARNING    => 'warning'
+		];
+
+		return isset($statuses[$status]) ? $statuses[$status] : null;
+	}
+
+	protected function resolveClockworkAssertsRan()
+	{
+		$assertsRan = static::$clockwork['assertsRan'];
+
+		if ($this->getStatus() == BaseTestRunner::STATUS_FAILURE) {
+			$assertsRan[count($assertsRan) - 1]['passed'] = false;
+		}
+
+		static::$clockwork['assertsRan'] = [];
+
+		return $assertsRan;
+	}
+
+	protected static function logClockworkAssertRan($assert, $arguments)
+	{
+	}
+
+	public static function assertThat($value, Constraint $constraint, string $message = ''): void
+	{
+		$trace = StackTrace::get([ 'arguments' => true, 'limit' => 10 ]);
+
+		$assertFrame = $trace->filter(function ($frame) { return strpos($frame->function, 'assert') === 0; })->last();
+
+		static::$clockwork['assertsRan'][] = [
+			'name'      => $assertFrame->function,
+			'arguments' => $assertFrame->args,
+			'trace'     => (new Serializer)->trace($trace),
+			'passed'    => true
+		];
+
+		parent::assertThat($value, $constraint, $message);
+	}
+}

--- a/Clockwork/Support/Laravel/Tests/UsesClockwork.php
+++ b/Clockwork/Support/Laravel/Tests/UsesClockwork.php
@@ -1,6 +1,7 @@
 <?php namespace Clockwork\Support\Laravel\Tests;
 
 use Clockwork\Helpers\Serializer;
+use Clockwork\Helpers\StackFilter;
 use Clockwork\Helpers\StackTrace;
 
 use PHPUnit\Framework\Constraint\Constraint;
@@ -64,6 +65,7 @@ trait UsesClockwork
 		$trace = StackTrace::get([ 'arguments' => true, 'limit' => 10 ]);
 
 		$assertFrame = $trace->filter(function ($frame) { return strpos($frame->function, 'assert') === 0; })->last();
+		$trace = $trace->skip(StackFilter::make()->isNotVendor([ 'itsgoingd', 'phpunit' ]))->limit(3);
 
 		static::$clockwork['asserts'][] = [
 			'name'      => $assertFrame->function,

--- a/Clockwork/Support/Laravel/Tests/UsesClockwork.php
+++ b/Clockwork/Support/Laravel/Tests/UsesClockwork.php
@@ -15,6 +15,8 @@ trait UsesClockwork
 	protected function setUpClockwork()
 	{
 		$this->beforeApplicationDestroyed(function () {
+			if ($this->app->make('clockwork.support')->isTestFiltered($this->toString())) return;
+
 			$this->app->make('clockwork')
 				->resolveAsTest(
 					$this->toString(),

--- a/Clockwork/Support/Laravel/config/clockwork.php
+++ b/Clockwork/Support/Laravel/config/clockwork.php
@@ -171,6 +171,20 @@ return [
 
 	/*
 	|--------------------------------------------------------------------------
+	| Tests collection
+	|--------------------------------------------------------------------------
+	|
+	| You can enable or disable and configure collection of ran tests here.
+	|
+	*/
+
+	'tests' => [
+		// Enable or disable collection of ran tests
+		'collect' => env('CLOCKWORK_TESTS_COLLECT', false)
+	],
+
+	/*
+	|--------------------------------------------------------------------------
 	| Enable data collection, when Clockwork is disabled
 	|--------------------------------------------------------------------------
 	|

--- a/Clockwork/Support/Laravel/config/clockwork.php
+++ b/Clockwork/Support/Laravel/config/clockwork.php
@@ -180,7 +180,12 @@ return [
 
 	'tests' => [
 		// Enable or disable collection of ran tests
-		'collect' => env('CLOCKWORK_TESTS_COLLECT', false)
+		'collect' => env('CLOCKWORK_TESTS_COLLECT', false),
+
+		// List of tests that should not be collected
+		'except' => [
+			// Tests\Unit\ExampleTest::class
+		]
 	],
 
 	/*


### PR DESCRIPTION
This PR adds an ability to collect ran tests as "requests" to be shown in the Clockwork app. Every test ran, eg. `RssEntryDecoratorTest::content_can_be_parsed`, is shown as a request.

These requests have all the metadata, like timeline, executed database queries, log messages, etc. collected during the test run and test-specific metadata like test name, status (passed, failed, skipped..), list of asserts with arguments and failure message.

Included is a Laravel integration that can be enabled by adding a Clockwork testing trait to `tests/TestCase.php`:

```php
use Clockwork\Support\Laravel\Tests\UsesClockwork;

abstract class TestCase extends BaseTestCase
{
    use CreatesApplication, DatabaseMigrations, UsesClockwork;
}
```

(see app PR for screenshots)

- added "type" to requests (currently "request" or "test") and test-specific metadata (testName, testStatus, testStatusMessage, testAsserts)
- added `Clockwork::resolveTest` method for resolving current request as "test" request with test-specific metadata
- added support for collecting test runs in Laravel integration (w/ default PHPUnit setup)
- app PR - https://github.com/underground-works/clockwork-app/pull/23
