### PR TITLE
Twig profiler & views profiling tweaks

### DIFF
--- a/Clockwork/DataSource/LaravelDataSource.php
+++ b/Clockwork/DataSource/LaravelDataSource.php
@@ -43,7 +43,10 @@ class LaravelDataSource extends DataSource
 	protected $collectLog = true;
 
 	// Whether we should collect views
-	protected $collectViews = false;
+	protected $collectViews = true;
+
+	// Whether we should collect view data when collecting views
+	protected $collectViewsData = false;
 
 	// Whether we should collect routes
 	protected $collectRoutes = false;
@@ -51,11 +54,12 @@ class LaravelDataSource extends DataSource
 	/**
 	 * Create a new data source, takes Laravel application instance as an argument
 	 */
-	public function __construct(Application $app, $collectLog = true, $collectViews = false, $collectRoutes = false)
+	public function __construct(Application $app, $collectLog = true, $collectViews = true, $collectRoutes = false, $collectViewsData = false)
 	{
 		$this->app = $app;
 		$this->collectLog = $collectLog;
 		$this->collectViews = $collectViews;
+		$this->collectViewsData = $collectViewsData;
 		$this->collectRoutes = $collectRoutes;
 
 		$this->timeline = new Timeline();
@@ -140,16 +144,16 @@ class LaravelDataSource extends DataSource
 					$view = $data[0];
 				}
 
-				$time = microtime(true);
-
-				$data = array_filter($view->getData(), function ($v, $k) {
-					return strpos($k, '__') !== 0;
-				}, \ARRAY_FILTER_USE_BOTH);
+				$data = array_filter(
+					$this->collectViewsData ? $view->getData() : [],
+					function ($v, $k) { return strpos($k, '__') !== 0; },
+					\ARRAY_FILTER_USE_BOTH
+				);
 
 				$this->views->addEvent(
 					'view ' . $view->getName(),
 					'Rendering a view',
-					$time,
+					$time = microtime(true),
 					$time,
 					[ 'name' => $view->getName(), 'data' => (new Serializer)->normalize($data) ]
 				);

--- a/Clockwork/DataSource/LaravelDataSource.php
+++ b/Clockwork/DataSource/LaravelDataSource.php
@@ -141,8 +141,10 @@ class LaravelDataSource extends DataSource
 				}
 
 				$time = microtime(true);
-				$data = $view->getData();
-				unset($data['__env']);
+
+				$data = array_filter($view->getData(), function ($v, $k) {
+					return strpos($k, '__') !== 0;
+				}, \ARRAY_FILTER_USE_BOTH);
 
 				$this->views->addEvent(
 					'view ' . $view->getName(),

--- a/Clockwork/DataSource/LaravelViewsDataSource.php
+++ b/Clockwork/DataSource/LaravelViewsDataSource.php
@@ -1,0 +1,64 @@
+<?php namespace Clockwork\DataSource;
+
+use Clockwork\DataSource\DataSource;
+use Clockwork\Helpers\Serializer;
+use Clockwork\Request\Request;
+use Clockwork\Request\Timeline;
+
+use Illuminate\Contracts\Events\Dispatcher;
+
+/**
+ * Data source for Laravel views component, provides rendered views
+ */
+class LaravelViewsDataSource extends DataSource
+{
+	// Event dispatcher
+	protected $dispatcher;
+
+	// Timeline data structure for collected views
+	protected $views;
+
+	// Whether we should collect view data
+	protected $collectData = false;
+
+	// Create a new data source instance, takes an event dispatcher as argument
+	public function __construct(Dispatcher $dispatcher, $collectData = false)
+	{
+		$this->dispatcher = $dispatcher;
+		$this->collectData = $collectData;
+
+		$this->views = new Timeline;
+	}
+
+	// Adds rendered views to the request
+	public function resolve(Request $request)
+	{
+		$request->viewsData = array_merge($request->viewsData, $this->views->finalize());
+
+		return $request;
+	}
+
+	// Start listening to the events
+	public function listenToEvents()
+	{
+		$this->dispatcher->listen('composing:*', function ($view, $data = null) {
+			if (is_string($view) && is_array($data)) { // Laravel 5.4 wildcard event
+				$view = $data[0];
+			}
+
+			$data = array_filter(
+				$this->collectData ? $view->getData() : [],
+				function ($v, $k) { return strpos($k, '__') !== 0; },
+				\ARRAY_FILTER_USE_BOTH
+			);
+
+			$this->views->addEvent(
+				'view ' . $view->getName(),
+				'Rendering a view',
+				$time = microtime(true),
+				$time,
+				[ 'name' => $view->getName(), 'data' => (new Serializer)->normalize($data) ]
+			);
+		});
+	}
+}

--- a/Clockwork/DataSource/TwigDataSource.php
+++ b/Clockwork/DataSource/TwigDataSource.php
@@ -12,6 +12,10 @@ use Twig_Profiler_Profile;
  */
 class TwigDataSource extends DataSource
 {
+	// Profiled Twig environment instance
+	protected $twig;
+
+	// Twig profile instance
 	protected $profile;
 
 	/**
@@ -19,7 +23,13 @@ class TwigDataSource extends DataSource
 	 */
 	public function __construct(Twig_Environment $twig)
 	{
-		$twig->addExtension(new Twig_Extension_Profiler($this->profile = new Twig_Profiler_Profile));
+		$this->twig = $twig;
+	}
+
+	// Register the Twig profiler extension
+	public function listenToEvents()
+	{
+		$this->twig->addExtension(new Twig_Extension_Profiler($this->profile = new Twig_Profiler_Profile));
 	}
 
 	/**

--- a/Clockwork/DataSource/TwigDataSource.php
+++ b/Clockwork/DataSource/TwigDataSource.php
@@ -1,0 +1,36 @@
+<?php namespace Clockwork\DataSource;
+
+use Clockwork\Request\Request;
+use Clockwork\Support\Twig\ProfilerClockworkDumper;
+
+use Twig_Environment;
+use Twig_Extension_Profiler;
+use Twig_Profiler_Profile;
+
+/**
+ * Data source for Twig, provides views data
+ */
+class TwigDataSource extends DataSource
+{
+	protected $profile;
+
+	/**
+	 * Create a new data source, takes Twig instance as an argument
+	 */
+	public function __construct(Twig_Environment $twig)
+	{
+		$twig->addExtension(new Twig_Extension_Profiler($this->profile = new Twig_Profiler_Profile));
+	}
+
+	/**
+	 * Adds email data to the request
+	 */
+	public function resolve(Request $request)
+	{
+		$timeline = (new ProfilerClockworkDumper)->dump($this->profile);
+
+		$request->viewsData = array_merge($request->viewsData, $timeline->finalize());
+
+		return $request;
+	}
+}

--- a/Clockwork/Support/Laravel/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Laravel/ClockworkServiceProvider.php
@@ -183,7 +183,8 @@ class ClockworkServiceProvider extends ServiceProvider
 				$app,
 				$app['clockwork.support']->isFeatureEnabled('log'),
 				$app['clockwork.support']->isFeatureEnabled('views'),
-				$app['clockwork.support']->isFeatureEnabled('routes')
+				$app['clockwork.support']->isFeatureEnabled('routes'),
+				$app['clockwork.support']->getConfig('features.views.collect_data')
 			))
 				->setLog($app['clockwork.log']);
 		});

--- a/Clockwork/Support/Laravel/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Laravel/ClockworkServiceProvider.php
@@ -8,8 +8,11 @@ use Clockwork\DataSource\LaravelCacheDataSource;
 use Clockwork\DataSource\LaravelEventsDataSource;
 use Clockwork\DataSource\LaravelRedisDataSource;
 use Clockwork\DataSource\LaravelQueueDataSource;
+use Clockwork\DataSource\LaravelTwigDataSource;
+use Clockwork\DataSource\LaravelViewsDataSource;
 use Clockwork\DataSource\PhpDataSource;
 use Clockwork\DataSource\SwiftDataSource;
+use Clockwork\DataSource\TwigDataSource;
 use Clockwork\DataSource\XdebugDataSource;
 use Clockwork\Helpers\StackFilter;
 use Clockwork\Request\Log;
@@ -54,6 +57,10 @@ class ClockworkServiceProvider extends ServiceProvider
 			$this->app[RedisManager::class]->enableEvents();
 			$this->app['clockwork.redis']->listenToEvents();
 		}
+		if ($support->isFeatureEnabled('views')) {
+			$support->getConfig('features.views.use_twig_profiler', false)
+				? $this->app['clockwork.twig']->listenToEvents() : $this->app['clockwork.views']->listenToEvents();
+		}
 
 		if ($support->isCollectingCommands()) $support->collectCommands();
 		if ($support->isCollectingQueueJobs()) $support->collectQueueJobs();
@@ -87,6 +94,11 @@ class ClockworkServiceProvider extends ServiceProvider
 			if ($support->isFeatureEnabled('events')) $clockwork->addDataSource($app['clockwork.events']);
 			if ($support->isFeatureEnabled('emails')) $clockwork->addDataSource($app['clockwork.swift']);
 			if ($support->isFeatureAvailable('xdebug')) $clockwork->addDataSource($app['clockwork.xdebug']);
+			if ($support->isFeatureEnabled('views')) {
+				$clockwork->addDataSource(
+					$support->getConfig('features.views.use_twig_profiler', false) ? $app['clockwork.twig'] : $app['clockwork.views']
+				);
+			}
 
 			return $clockwork;
 		});
@@ -181,10 +193,7 @@ class ClockworkServiceProvider extends ServiceProvider
 		$this->app->singleton('clockwork.laravel', function ($app) {
 			return (new LaravelDataSource(
 				$app,
-				$app['clockwork.support']->isFeatureEnabled('log'),
-				$app['clockwork.support']->isFeatureEnabled('views'),
-				$app['clockwork.support']->isFeatureEnabled('routes'),
-				$app['clockwork.support']->getConfig('features.views.collect_data')
+				$app['clockwork.support']->isFeatureEnabled('routes')
 			))
 				->setLog($app['clockwork.log']);
 		});
@@ -213,6 +222,17 @@ class ClockworkServiceProvider extends ServiceProvider
 
 		$this->app->singleton('clockwork.swift', function ($app) {
 			return new SwiftDataSource($app['mailer']->getSwiftMailer());
+		});
+
+		$this->app->singleton('clockwork.twig', function ($app) {
+			return new TwigDataSource($app['twig']);
+		});
+
+		$this->app->singleton('clockwork.views', function ($app) {
+			return new LaravelViewsDataSource(
+				$app['events'],
+				$app['clockwork.support']->getConfig('features.views.collect_data')
+			);
 		});
 
 		$this->app->singleton('clockwork.xdebug', function ($app) {

--- a/Clockwork/Support/Laravel/config/clockwork.php
+++ b/Clockwork/Support/Laravel/config/clockwork.php
@@ -91,9 +91,12 @@ return [
 			'enabled' => env('CLOCKWORK_ROUTES_ENABLED', false)
 		],
 
-		// Rendered views including passed data (high performance impact with large amount of data passed to views)
+		// Rendered views
 		'views' => [
-			'enabled' => env('CLOCKWORK_VIEWS_ENABLED', false)
+			'enabled' => env('CLOCKWORK_VIEWS_ENABLED', true),
+
+			// Collect views including view data (high performance impact with a high number of views)
+			'collect_data' => env('CLOCKWORK_VIEWS_COLLECT_DATA', false)
 		]
 
 	],

--- a/Clockwork/Support/Laravel/config/clockwork.php
+++ b/Clockwork/Support/Laravel/config/clockwork.php
@@ -96,7 +96,11 @@ return [
 			'enabled' => env('CLOCKWORK_VIEWS_ENABLED', true),
 
 			// Collect views including view data (high performance impact with a high number of views)
-			'collect_data' => env('CLOCKWORK_VIEWS_COLLECT_DATA', false)
+			'collect_data' => env('CLOCKWORK_VIEWS_COLLECT_DATA', false),
+
+			// Use Twig profiler instead of Laravel events for apps using laravel-twigbridge (more precise, but does
+			// not support collecting view data)
+			'use_twig_profiler' => env('CLOCKWORK_VIEWS_USE_TWIG_PROFILER', false)
 		]
 
 	],

--- a/Clockwork/Support/Twig/ProfilerClockworkDumper.php
+++ b/Clockwork/Support/Twig/ProfilerClockworkDumper.php
@@ -33,12 +33,14 @@ class ProfilerClockworkDumper
 			$this->dumpProfile($p, $timeline, $id);
 		}
 
+		$data = $profile->__serialize();
+
 		$timeline->addEvent(
 			$id,
 			$name,
-			$profile->__serialize()[3]['wt'],
-			$profile->__serialize()[4]['wt'],
-			[ 'data' => [], 'parent' => $parent ]
+			isset($data[3]['wt']) ? $data[3]['wt'] : null,
+			isset($data[4]['wt']) ? $data[4]['wt'] : null,
+			[ 'data' => [], 'memoryUsage' => isset($data[4]['mu']) ? $data[4]['mu'] : null, 'parent' => $parent ]
 		);
 	}
 }

--- a/Clockwork/Support/Twig/ProfilerClockworkDumper.php
+++ b/Clockwork/Support/Twig/ProfilerClockworkDumper.php
@@ -1,0 +1,44 @@
+<?php namespace Clockwork\Support\Twig;
+
+use Clockwork\Request\Timeline;
+
+use Twig\Profiler\Profile;
+
+class ProfilerClockworkDumper
+{
+	protected $lastId = 1;
+
+	public function dump(Profile $profile)
+	{
+		$timeline = new Timeline;
+
+		$this->dumpProfile($profile, $timeline);
+
+		return $timeline;
+	}
+
+	public function dumpProfile(Profile $profile, Timeline $timeline, $parent = null)
+	{
+		$id = $this->lastId++;
+
+		if ($profile->isRoot()) {
+			$name = $profile->getName();
+		} elseif ($profile->isTemplate()) {
+			$name = basename($profile->getTemplate());
+		} else {
+			$name = basename($profile->getTemplate()) . '::' . $profile->getType() . '(' . $profile->getName() . ')';
+		}
+
+		foreach ($profile as $p) {
+			$this->dumpProfile($p, $timeline, $id);
+		}
+
+		$timeline->addEvent(
+			$id,
+			$name,
+			$profile->__serialize()[3]['wt'],
+			$profile->__serialize()[4]['wt'],
+			[ 'data' => [], 'parent' => $parent ]
+		);
+	}
+}


### PR DESCRIPTION
- added new TwigDataSource using the built-in Twig profiler extension and custom Clockwork profile dumper to collect views profiling data directly from Twig
- Twig profiler provides more precise data and memory usage, it does not support collecting view data
- added `features.views.collect_data` option to enable/disable collecting of view data when collecting Laravel views (collecting of views is now enabled and view data disabled by default)
- added `features.views.use_twig_profiler` option to use the Twig profiler over the default Laravel view events (requires laravel-twigbridge compatible twig integration, disabled by default)
- strip all data prefixed with `__` when collecting Laravel views data (strips lots of useless metadata)
- app PR - https://github.com/underground-works/clockwork-app/pull/26