### PR TITLE
Fix FileStorage cleanup not working

### DIFF
--- a/Clockwork/Storage/FileStorage.php
+++ b/Clockwork/Storage/FileStorage.php
@@ -98,7 +98,7 @@ class FileStorage extends Storage
 	{
 		if ($this->expiration === false || (! $force && rand(1, $this->cleanupChance) != 1)) return;
 
-		$this->openIndex('start', true, true); // reopan index with lock
+		$this->openIndex('end', true, true); // reopen index with lock
 
 		$expirationTime = time() - ($this->expiration * 60);
 


### PR DESCRIPTION
The cleanup routine opens the index at the start instead of end, then proceeds by searching backwards. The `searchIndexBackwards` routine has its own behaviour of opening the index at the end, but since the index was already open it would return early and never get to the point of `fseek()`-ing to the end.