### PR TITLE
Fixed #364: Serializer breaks with deep nested structures

### DIFF
--- a/Clockwork/Helpers/Serializer.php
+++ b/Clockwork/Helpers/Serializer.php
@@ -36,7 +36,9 @@ class Serializer
 		if ($context === null) $context = [ 'references' => [] ];
 		if ($limit === null) $limit = $this->options['limit'];
 
-		if ($limit < 1) return $data;
+		if ($limit < 1) {
+		    return [ '__type__' => '...' ];
+		}
 
 		if ($data instanceof \Closure) {
 			return [ '__type__' => 'anonymous function' ];


### PR DESCRIPTION
This pull request fixes #364.

Data returned by serializer was corrupted for deeply nested structures. Instead of cutting down the data, raw data was returned instead.

I'm using type `...`, but this can be changed.