### PR TITLE
Prefer using $data->__debugInfo() when serializing object

### DIFF
--- a/Clockwork/Helpers/Serializer.php
+++ b/Clockwork/Helpers/Serializer.php
@@ -66,7 +66,11 @@ class Serializer
 				return $this->cache[$objectHash] = [ '__class__' => $className ];
 			}
 
-			$data = (array) $data;
+			if (method_exists($data, '__debugInfo')) {
+				$data = (array) $data->__debugInfo();
+			} else {
+				$data = (array) $data;
+			}
 			$data = array_column(array_map(function ($key, $item) use ($className, $context, $limit) {
 				return [
 					// replace null-byte prefixes of protected and private properties used by php with * (protected)


### PR DESCRIPTION
Related to #369.

To trim down the amount of serialized data and make the dump more readable, add support for using `$data->__debugInfo()` when it is available.

This will
* greatly speed up serializer when serializing objects with `__debugInfo()`
* greatly speed up GUI as there is far less data to be downloaded and processed
* greatly improve readability as objects do not have redundant dumped data
