### PR TITLE
Serializer minor improvements

### DIFF
--- a/Clockwork/Helpers/Serializer.php
+++ b/Clockwork/Helpers/Serializer.php
@@ -12,7 +12,10 @@ class Serializer
 			\Laravel\Lumen\Application::class
 		],
 		'limit' => 10,
+		'toArray' => false,
 		'toString' => false,
+		'debugInfo' => true,
+		'jsonSerialize' => false,
 		'traces' => true,
 		'tracesFilter' => null,
 		'tracesSkip' => null,
@@ -68,11 +71,16 @@ class Serializer
 				return $this->cache[$objectHash] = [ '__class__' => $className, '__omitted__' => 'blackbox' ];
 			}
 
-			if (method_exists($data, '__debugInfo')) {
+			if ($this->options['debugInfo'] && method_exists($data, '__debugInfo')) {
 				$data = (array) $data->__debugInfo();
+			} elseif ($this->options['jsonSerialize'] && method_exists($data, 'jsonSerialize')) {
+				$data = (array) $data->jsonSerialize();
+			} elseif ($this->options['toArray'] && method_exists($data, 'toArray')) {
+				$data = (array) $data->toArray();
 			} else {
 				$data = (array) $data;
 			}
+
 			$data = array_column(array_map(function ($key, $item) use ($className, $context, $limit) {
 				return [
 					// replace null-byte prefixes of protected and private properties used by php with * (protected)

--- a/Clockwork/Request/Log.php
+++ b/Clockwork/Request/Log.php
@@ -18,7 +18,7 @@ class Log extends AbstractLogger
 	public $data = [];
 
 	/**
-	 * Add a new timestamped message, with a level and context,
+	 * Add a new timestamped message, with a level and context, context can be used to override serializer defaults
 	 * $context['trace'] = true can be used to force collecting a stack trace
 	 */
 	public function log($level = LogLevel::INFO, $message, array $context = [])
@@ -26,7 +26,7 @@ class Log extends AbstractLogger
 		$trace = $this->hasTrace($context) ? $context['trace'] : StackTrace::get()->resolveViewName();
 
 		$this->data[] = [
-			'message'   => (new Serializer([ 'toString' => true ]))->normalize($message),
+			'message'   => (new Serializer($context))->normalize($message),
 			'exception' => $this->formatException($context),
 			'context'   => $this->formatContext($context),
 			'level'     => $level,


### PR DESCRIPTION
- reworked limit implementation - now omits the data instead of serializing them raw, limit is applied on the array/object level and omitted data is marked as such in the metadata output
- added support for `__debugInfo`, `jsonSerialize` and `toArray` behind new configuration options (`debugInfo` enabled by default)
- fixed string serialized objects not being cached
- log api now allows overriding serializer options via context, no longer enables `toString` by default
- based on PRs https://github.com/itsgoingd/clockwork/pull/369 and https://github.com/itsgoingd/clockwork/pull/371 by @mahagr 

TODO

- consider enabling `toArray` by default - better for Eloquent most of the time (but not always)
- take care of https://github.com/itsgoingd/clockwork/issues/352 or leave for 4.2?