### PR TITLE
Unlock the index even if expirable entries don't exist

### DIFF
--- a/Clockwork/Storage/FileStorage.php
+++ b/Clockwork/Storage/FileStorage.php
@@ -106,7 +106,10 @@ class FileStorage extends Storage
 			new Search([ 'received' => [ '<' . date('c', $expirationTime) ] ], [ 'stopOnFirstMismatch' => true ])
 		);
 
-		if (! count($old)) return;
+		if (! count($old)) {
+		    $this->closeIndex(true);
+		    return;
+        };
 
 		$this->readPreviousIndex();
 		$this->trimIndex();


### PR DESCRIPTION
When attempting to remove expired records, if no expirable records exist, the index remains open. 

All subsequent requests will time out.

This ensures that the index is closed.