### PR TITLE
Added support for collecting model actions and counts

### DIFF
--- a/Clockwork/Request/Request.php
+++ b/Clockwork/Request/Request.php
@@ -143,6 +143,15 @@ class Request
 	 */
 	public $cacheTime;
 
+	// Model actions
+	public $modelsActions = [];
+
+	// Model action counts by model
+	public $modelsRetrieved;
+	public $modelsCreated;
+	public $modelsUpdated;
+	public $modelsDeleted;
+
 	// Redis commands
 	public $redisCommands = [];
 
@@ -318,6 +327,11 @@ class Request
 			'cacheWrites'              => $this->cacheWrites,
 			'cacheDeletes'             => $this->cacheDeletes,
 			'cacheTime'                => $this->cacheTime,
+			'modelsActions'            => $this->modelsActions,
+			'modelsRetrieved'          => $this->modelsRetrieved,
+			'modelsCreated'            => $this->modelsCreated,
+			'modelsUpdated'            => $this->modelsUpdated,
+			'modelsDeleted'            => $this->modelsDeleted,
 			'redisCommands'            => $this->redisCommands,
 			'queueJobs'                => $this->queueJobs,
 			'timelineData'             => $this->timelineData,

--- a/Clockwork/Request/Request.php
+++ b/Clockwork/Request/Request.php
@@ -396,6 +396,28 @@ class Request
 		];
 	}
 
+	// Add model action, takes model, action and additional data - key, attributes, changes, time (when was the action
+	// executed), query, duration (in ms), connection (connection name), trace (serialized trace), file (caller file
+	// name), line (caller line number), tags
+	public function addModelAction($model, $action, $data = [])
+	{
+		$this->modelActions[] = [
+			'model'      => $model,
+			'key'        => isset($data['key']) ? $data['key'] : null,
+			'action'     => $action,
+			'attributes' => isset($data['attributes']) ? $data['attributes'] : [],
+			'changes'    => isset($data['changes']) ? $data['changes'] : [],
+			'time'       => isset($data['time']) ? $data['time'] : microtime(true) / 1000,
+			'query'      => isset($data['query']) ? $data['query'] : null,
+			'duration'   => isset($data['duration']) ? $data['duration'] : null,
+			'connection' => isset($data['connection']) ? $data['connection'] : null,
+			'trace'      => isset($data['trace']) ? $data['trace'] : null,
+			'file'       => isset($data['file']) ? $data['file'] : null,
+			'line'       => isset($data['line']) ? $data['line'] : null,
+			'tags'       => isset($data['tags']) ? $data['tags'] : []
+		];
+	}
+
 	// Add cache query, takes type, key, value, duration (in ms) and additional data - connection (connection name),
 	// time (when was the query executed), file (caller file name), line (caller line number), trace (serialized trace),
 	// expiration

--- a/Clockwork/Storage/SqlStorage.php
+++ b/Clockwork/Storage/SqlStorage.php
@@ -56,6 +56,11 @@ class SqlStorage extends Storage
 		'cacheWrites'              => 'INTEGER NULL',
 		'cacheDeletes'             => 'INTEGER NULL',
 		'cacheTime'                => 'DOUBLE PRECISION NULL',
+		'modelsActions'            => 'TEXT NULL',
+		'modelsRetrieved'          => 'TEXT NULL',
+		'modelsCreated'            => 'TEXT NULL',
+		'modelsUpdated'            => 'TEXT NULL',
+		'modelsDeleted'            => 'TEXT NULL',
 		'redisCommands'            => 'TEXT NULL',
 		'queueJobs'                => 'TEXT NULL',
 		'timelineData'             => 'TEXT NULL',
@@ -91,8 +96,9 @@ class SqlStorage extends Storage
 	// List of Request keys that need to be serialized before they can be stored in database
 	protected $needsSerialization = [
 		'headers', 'getData', 'postData', 'requestData', 'sessionData', 'authenticatedUser', 'cookies', 'middleware',
-		'databaseQueries', 'cacheQueries', 'redisCommands', 'queueJobs', 'timelineData', 'log', 'events', 'routes',
-		'emailsData', 'viewsData', 'userData', 'subrequests', 'xdebug', 'commandArguments', 'commandArgumentsDefaults',
+		'databaseQueries', 'cacheQueries', 'modelsActions', 'modelsRetrieved', 'modelsCreated', 'modelsUpdated',
+		'modelsDeleted', 'redisCommands', 'queueJobs', 'timelineData', 'log', 'events', 'routes', 'emailsData',
+		'viewsData', 'userData', 'subrequests', 'xdebug', 'commandArguments', 'commandArgumentsDefaults',
 		'commandOptions', 'commandOptionsDefaults', 'jobPayload', 'jobOptions', 'testAsserts', 'parent'
 	];
 

--- a/Clockwork/Support/Laravel/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Laravel/ClockworkServiceProvider.php
@@ -163,7 +163,9 @@ class ClockworkServiceProvider extends ServiceProvider
 				$app['clockwork.support']->getConfig('features.database.collect_queries'),
 				$app['clockwork.support']->getConfig('features.database.slow_threshold'),
 				$app['clockwork.support']->getConfig('features.database.slow_only'),
-				$app['clockwork.support']->getConfig('features.database.detect_duplicate_queries')
+				$app['clockwork.support']->getConfig('features.database.detect_duplicate_queries'),
+				$app['clockwork.support']->getConfig('features.database.collect_models_actions'),
+				$app['clockwork.support']->getConfig('features.database.collect_models_retrieved')
 			));
 
 			// if we are collecting queue jobs, filter out queries caused by the database queue implementation

--- a/Clockwork/Support/Laravel/config/clockwork.php
+++ b/Clockwork/Support/Laravel/config/clockwork.php
@@ -45,6 +45,12 @@ return [
 			// Collect database queries (high performance impact with a very high number of queries)
 			'collect_queries' => env('CLOCKWORK_DATABASE_COLLECT_QUERIES', true),
 
+			// Collect details of models updates (high performance impact with a lot of model updates)
+			'collect_models_actions' => env('CLOCKWORK_DATABASE_COLLECT_MODELS_ACTIONS', true),
+
+			// Collect details of retrieved models (very high performance impact with a lot of models retrieved)
+			'collect_models_retrieved' => env('CLOCKWORK_DATABASE_COLLECT_MODELS_RETRIEVED', false),
+
 			// Query execution time threshold in miliseconds after which the query will be marked as slow
 			'slow_threshold' => env('CLOCKWORK_DATABASE_SLOW_THRESHOLD'),
 


### PR DESCRIPTION
- added support for collecting number of retrieved, created, updated and deleted models
- added support for collecting individual model actions, including model name, primary key, attributes, changes and stack trace
- supported in EloquentDataSource w/ new configuration options (by default collect only counts and update actions)
- https://github.com/underground-works/clockwork-app/pull/41

## todo

- consider refactoring how we pass options to EloquentDataSource (too many options)
- test with old Laravel versions
