### PR TITLE
Fix ErrorException when collecting Artisan Command with array inputs

### DIFF
--- a/Clockwork/Support/Laravel/ClockworkSupport.php
+++ b/Clockwork/Support/Laravel/ClockworkSupport.php
@@ -147,11 +147,11 @@ class ClockworkSupport
 			$inputArguments = $event->input->getArguments();
 			$inputOptions = $event->input->getOptions();
 			$comparator = function($a, $b) {
-				return strcmp(serialize($a), serialize($b));
+				return $a === $b ? 0 : 1;
 			};
-			$arguments = array_udiff($inputArguments, $argumentsDefaults, $comparator);
-			$options = array_udiff($inputOptions, $optionsDefaults, $comparator);
-
+			$arguments =  array_udiff_assoc($inputArguments, $argumentsDefaults, $comparator);
+			$options = array_udiff_assoc($inputOptions, $optionsDefaults, $comparator);
+			dump($options);
 			$this->app->make('clockwork')
 				->resolveAsCommand(
 					$event->command,

--- a/Clockwork/Support/Laravel/ClockworkSupport.php
+++ b/Clockwork/Support/Laravel/ClockworkSupport.php
@@ -144,13 +144,20 @@ class ClockworkSupport
 
 			$argumentsDefaults = $command->getDefinition()->getArgumentDefaults();
 			$optionsDefaults = $command->getDefinition()->getOptionDefaults();
+			$inputArguments = $event->input->getArguments();
+			$inputOptions = $event->input->getOptions();
+			$comparator = function($a, $b) {
+				return strcmp(serialize($a), serialize($b));
+			};
+			$arguments = array_udiff($inputArguments, $argumentsDefaults, $comparator);
+			$options = array_udiff($inputOptions, $optionsDefaults, $comparator);
 
 			$this->app->make('clockwork')
 				->resolveAsCommand(
 					$event->command,
 					$event->exitCode,
-					array_diff($event->input->getArguments(), $argumentsDefaults),
-					array_diff($event->input->getOptions(), $optionsDefaults),
+					$arguments,
+					$options,
 					$argumentsDefaults,
 					$optionsDefaults,
 					$this->getConfig('artisan.collect_output') ? $event->output->getFormatter()->capturedOutput() : null


### PR DESCRIPTION
This fixes an issue where Clockwork would throw an `ErrorException` (array to string conversion) when running an artisan command where the argument (or option) value is an array.

I don't know if my simple `array_udiff` comparator is the best way to go about it, but it gets the job done.