### PR TITLE
Filter requests by http method

### DIFF
--- a/Clockwork/Support/Laravel/ClockworkSupport.php
+++ b/Clockwork/Support/Laravel/ClockworkSupport.php
@@ -317,6 +317,7 @@ class ClockworkSupport
 	{
 		return ($this->isEnabled() || $this->getConfig('collect_data_always', false))
 			&& ! $this->app->runningInConsole()
+			&& ! $this->isMethodFiltered($this->app['request']->getMethod())
 			&& ! $this->isUriFiltered($this->app['request']->getRequestUri());
 	}
 
@@ -364,6 +365,14 @@ class ClockworkSupport
 		}
 
 		return false;
+	}
+
+	public function isMethodFiltered($method)
+	{
+		return in_array($method, array_map(
+			function ($method) { return strtoupper($method); },
+			$this->getConfig('filter_methods', [])
+		));
 	}
 
 	protected function isCommandFiltered($command)

--- a/Clockwork/Support/Laravel/config/clockwork.php
+++ b/Clockwork/Support/Laravel/config/clockwork.php
@@ -267,17 +267,22 @@ return [
 
 	/*
 	|--------------------------------------------------------------------------
-	| Disable data collection for certain URIs
+	| Disable data collection for certain URIs or methods
 	|--------------------------------------------------------------------------
 	|
 	| You can disable data collection for specific URIs by adding matching
-	| regular expressions here.
+	| regular expressions here. You can also disable collecting all requests
+	| with a specific method.
 	|
 	*/
 
 	'filter_uris' => [
 		'/horizon/.*', // Laravel Horizon requests
 		'/telescope/.*' // Laravel Telescope requests
+	],
+
+	'filter_methods' => [
+		'options' // mostly used in the csrf pre-flight requests and is rarely of interest
 	],
 
 	/*

--- a/Clockwork/Support/Vanilla/config.php
+++ b/Clockwork/Support/Vanilla/config.php
@@ -85,6 +85,25 @@ return [
 
 	/*
 	|--------------------------------------------------------------------------
+	| Disable data collection for certain URIs or methods
+	|--------------------------------------------------------------------------
+	|
+	| You can disable data collection for specific URIs by adding matching
+	| regular expressions here. You can also disable collecting all requests
+	| with a specific method.
+	|
+	*/
+
+	'filter_uris' => [
+		// '/some/uri/.*'
+	],
+
+	'filter_methods' => [
+		'options' // mostly used in the csrf pre-flight requests and is rarely of interest
+	],
+
+	/*
+	|--------------------------------------------------------------------------
 	| Enable collecting of stack traces
 	|--------------------------------------------------------------------------
 	|


### PR DESCRIPTION
- added ability to filter collected requests by http methods in the laravel integration
- added ability to filter collected requests by uris and http methods in the vanilla integration
- filter OPTIONS requests by default (mostly used for csrf pre-flight requests which are of no interest)
- feature request https://github.com/itsgoingd/clockwork/issues/404