### PR TITLE
Requests collecting settings

### DIFF
--- a/Clockwork/Clockwork.php
+++ b/Clockwork/Clockwork.php
@@ -7,6 +7,8 @@ use Clockwork\Helpers\Serializer;
 use Clockwork\Request\Log;
 use Clockwork\Request\Request;
 use Clockwork\Request\RequestType;
+use Clockwork\Request\ShouldCollect;
+use Clockwork\Request\ShouldRecord;
 use Clockwork\Request\Timeline;
 use Clockwork\Storage\StorageInterface;
 
@@ -51,6 +53,12 @@ class Clockwork implements LoggerInterface
 	 */
 	protected $timeline;
 
+	// Callback to filter whether the request should be collected
+	protected $shouldCollect;
+
+	// Callback to filter whether the request should be recorded
+	protected $shouldRecord;
+
 	/**
 	 * Create a new Clockwork instance with default request object
 	 */
@@ -60,6 +68,9 @@ class Clockwork implements LoggerInterface
 		$this->log = new Log;
 		$this->timeline = new Timeline;
 		$this->authenticator = new NullAuthenticator;
+
+		$this->shouldCollect = new ShouldCollect;
+		$this->shouldRecord = new ShouldRecord;
 	}
 
 	/**
@@ -205,6 +216,24 @@ class Clockwork implements LoggerInterface
 		$this->timeline = new Timeline;
 
 		return $this;
+	}
+
+	public function shouldCollect($shouldCollect = null)
+	{
+		if ($shouldCollect instanceof Closure) return $this->shouldCollect->call($shouldCollect);
+
+		if (is_array($shouldCollect)) return $this->shouldCollect->merge($shouldCollect);
+
+		return $this->shouldCollect;
+	}
+
+	public function shouldRecord($shouldRecord = null)
+	{
+		if ($shouldRecord instanceof Closure) return $this->shouldRecord->call($shouldRecord);
+
+		if (is_array($shouldRecord)) return $this->shouldRecord->merge($shouldRecord);
+
+		return $this->shouldRecord;
 	}
 
 	/**

--- a/Clockwork/Clockwork.php
+++ b/Clockwork/Clockwork.php
@@ -220,7 +220,7 @@ class Clockwork implements LoggerInterface
 
 	public function shouldCollect($shouldCollect = null)
 	{
-		if ($shouldCollect instanceof Closure) return $this->shouldCollect->call($shouldCollect);
+		if ($shouldCollect instanceof Closure) return $this->shouldCollect->callback($shouldCollect);
 
 		if (is_array($shouldCollect)) return $this->shouldCollect->merge($shouldCollect);
 
@@ -229,7 +229,7 @@ class Clockwork implements LoggerInterface
 
 	public function shouldRecord($shouldRecord = null)
 	{
-		if ($shouldRecord instanceof Closure) return $this->shouldRecord->call($shouldRecord);
+		if ($shouldRecord instanceof Closure) return $this->shouldRecord->callback($shouldRecord);
 
 		if (is_array($shouldRecord)) return $this->shouldRecord->merge($shouldRecord);
 

--- a/Clockwork/Request/IncomingRequest.php
+++ b/Clockwork/Request/IncomingRequest.php
@@ -1,11 +1,16 @@
 <?php namespace Clockwork\Request;
 
+// Incoming HTTP request
 class IncomingRequest
 {
+	// Method
 	public $method;
+	// URI
 	public $uri;
 
+	// GET and POST data
 	public $input = [];
+	// Cookies
 	public $cookies = [];
 
 	public function __construct(array $data = [])

--- a/Clockwork/Request/IncomingRequest.php
+++ b/Clockwork/Request/IncomingRequest.php
@@ -1,0 +1,15 @@
+<?php namespace Clockwork\Request;
+
+class IncomingRequest
+{
+	public $method;
+	public $uri;
+
+	public $input = [];
+	public $cookies = [];
+
+	public function __construct(array $data = [])
+	{
+		foreach ($data as $key => $val) $this->$key = $val;
+	}
+}

--- a/Clockwork/Request/ShouldCollect.php
+++ b/Clockwork/Request/ShouldCollect.php
@@ -1,31 +1,25 @@
 <?php namespace Clockwork\Request;
 
+// Filter incoming requests before collecting data
 class ShouldCollect
 {
+	// Enable on-demand mode, boolean or the secret value
 	protected $onDemand = false;
+	// Enable sampling, chance to be sampled (eg. 100 to collect 1 in 100 requests)
 	protected $sample = false;
 
+	// List of URIs that should not be collected, can contain regexes
 	protected $except = [];
+	// List of URIs that should only be collected, can contain regexes (only used if non-empty)
 	protected $only = [];
 
+	// Disable collection of OPTIONS method requests (most commonly used for CORS pre-flight requests)
 	protected $exceptPreflight = false;
 
+	// Custom filter callback
 	protected $callback;
 
-	public function onDemand($onDemand = true)
-	{
-		$this->onDemand = $onDemand;
-
-		return $this;
-	}
-
-	public function sample($sample)
-	{
-		$this->sample = $sample;
-
-		return $this;
-	}
-
+	// Append one or more except URIs
 	public function except($uris)
 	{
 		$this->except = array_merge($this->except, is_array($uris) ? $uris : [ $uris ]);
@@ -33,6 +27,7 @@ class ShouldCollect
 		return $this;
 	}
 
+	// Append one or more only URIs
 	public function only($uris)
 	{
 		$this->only = array_merge($this->only, is_array($uris) ? $uris : [ $uris ]);
@@ -40,25 +35,13 @@ class ShouldCollect
 		return $this;
 	}
 
-	public function exceptPreflight($exceptPreflight = true)
-	{
-		$this->exceptPreflight = $exceptPreflight;
-
-		return $this;
-	}
-
-	public function call($callback)
-	{
-		$this->callback = $callback;
-
-		return $this;
-	}
-
+	// Merge multiple settings from array
 	public function merge(array $data = [])
 	{
 		foreach ($data as $key => $val) $this->$key = $val;
 	}
 
+	// Apply the filter to an incoming request
 	public function filter(IncomingRequest $request)
 	{
 		return $this->passOnDemand($request)
@@ -125,4 +108,13 @@ class ShouldCollect
 
 		return $this->callback($request);
 	}
+
+ 	public function __call($method, $parameters)
+ 	{
+ 		if (! count($parameters)) return $this->$method;
+
+ 		$this->$method = count($parameters) ? $parameters[0] : true;
+
+ 		return $this;
+ 	}
 }

--- a/Clockwork/Request/ShouldCollect.php
+++ b/Clockwork/Request/ShouldCollect.php
@@ -1,0 +1,128 @@
+<?php namespace Clockwork\Request;
+
+class ShouldCollect
+{
+	protected $onDemand = false;
+	protected $sample = false;
+
+	protected $except = [];
+	protected $only = [];
+
+	protected $exceptPreflight = false;
+
+	protected $callback;
+
+	public function onDemand($onDemand = true)
+	{
+		$this->onDemand = $onDemand;
+
+		return $this;
+	}
+
+	public function sample($sample)
+	{
+		$this->sample = $sample;
+
+		return $this;
+	}
+
+	public function except($uris)
+	{
+		$this->except = array_merge($this->except, is_array($uris) ? $uris : [ $uris ]);
+
+		return $this;
+	}
+
+	public function only($uris)
+	{
+		$this->only = array_merge($this->only, is_array($uris) ? $uris : [ $uris ]);
+
+		return $this;
+	}
+
+	public function exceptPreflight($exceptPreflight = true)
+	{
+		$this->exceptPreflight = $exceptPreflight;
+
+		return $this;
+	}
+
+	public function call($callback)
+	{
+		$this->callback = $callback;
+
+		return $this;
+	}
+
+	public function merge(array $data = [])
+	{
+		foreach ($data as $key => $val) $this->$key = $val;
+	}
+
+	public function filter(IncomingRequest $request)
+	{
+		return $this->passOnDemand($request)
+			&& $this->passSampling()
+			&& $this->passExcept($request)
+			&& $this->passOnly($request)
+			&& $this->passExceptPreflight($request)
+			&& $this->passCallback($request);
+	}
+
+	protected function passOnDemand(IncomingRequest $request)
+	{
+		if (! $this->onDemand) return true;
+
+		if ($this->onDemand !== true) {
+			$input = isset($request->input['clockwork-profile']) ? $request->input['clockwork-profile'] : '';
+			$cookie = isset($request->cookies['clockwork-profile']) ? $request->cookies['clockwork-profile'] : '';
+
+			return hash_equals($this->onDemand, $input) || hash_equals($this->onDemand, $cookie);
+		}
+
+		return isset($request->input['clockwork-profile']) || isset($request->cookies['clockwork-profile']);
+	}
+
+	protected function passSampling()
+	{
+		if (! $this->sample) return true;
+
+		return mt_rand(0, $this->sample) == $this->sample;
+	}
+
+	protected function passExcept(IncomingRequest $request)
+	{
+		if (! count($this->except)) return true;
+
+		foreach ($this->except as $pattern) {
+			if (preg_match('#' . str_replace('#', '\#', $pattern) . '#', $request->uri)) return false;
+		}
+
+		return true;
+	}
+
+	protected function passOnly(IncomingRequest $request)
+	{
+		if (! count($this->only)) return true;
+
+		foreach ($this->only as $pattern) {
+			if (preg_match('#' . str_replace('#', '\#', $pattern) . '#', $request->uri)) return true;
+		}
+
+		return false;
+	}
+
+	protected function passExceptPreflight(IncomingRequest $request)
+	{
+		if (! $this->exceptPreflight) return true;
+
+		return strtoupper($request->method) != 'OPTIONS';
+	}
+
+	protected function passCallback(IncomingRequest $request)
+	{
+		if (! $this->callback) return true;
+
+		return $this->callback($request);
+	}
+}

--- a/Clockwork/Request/ShouldRecord.php
+++ b/Clockwork/Request/ShouldRecord.php
@@ -1,0 +1,63 @@
+<?php namespace Clockwork\Request;
+
+class ShouldRecord
+{
+	protected $errorsOnly = false;
+	protected $slowOnly = false;
+
+	protected $callback;
+
+	public function errorsOnly($errorsOnly = true)
+	{
+		$this->errorsOnly = $errorsOnly;
+
+		return $this;
+	}
+
+	public function slowOnly($slowOnly)
+	{
+		$this->slowOnly = $slowOnly;
+
+		return $this;
+	}
+
+	public function call($callback)
+	{
+		$this->callback = $callback;
+
+		return $this;
+	}
+
+	public function merge(array $data = [])
+	{
+		foreach ($data as $key => $val) $this->$key = $val;
+	}
+
+	public function filter(Request $request)
+	{
+		return $this->passErrorsOnly($request)
+			&& $this->passSlowOnly($request)
+			&& $this->passCallback($request);
+	}
+
+	protected function passErrorsOnly(Request $request)
+	{
+		if (! $this->errorsOnly) return true;
+
+		return 400 <= $request->responseStatus && $request->responseStatus <= 599;
+	}
+
+	protected function passSlowOnly(Request $request)
+	{
+		if (! $this->slowOnly) return true;
+
+		return $request->getResponseDuration() >= $this->slowOnly;
+	}
+
+	protected function passCallback(Request $request)
+	{
+		if (! $this->callback) return true;
+
+		return $this->callback($request);
+	}
+}

--- a/Clockwork/Request/ShouldRecord.php
+++ b/Clockwork/Request/ShouldRecord.php
@@ -1,38 +1,23 @@
 <?php namespace Clockwork\Request;
 
+// Filter requests before recording
 class ShouldRecord
 {
+	// Enable collecting of errors only (requests with 4xx or 5xx responses)
 	protected $errorsOnly = false;
+	// Enable collecting of slow requests only, slow response time threshold in ms
 	protected $slowOnly = false;
 
+	// Custom filter callback
 	protected $callback;
 
-	public function errorsOnly($errorsOnly = true)
-	{
-		$this->errorsOnly = $errorsOnly;
-
-		return $this;
-	}
-
-	public function slowOnly($slowOnly)
-	{
-		$this->slowOnly = $slowOnly;
-
-		return $this;
-	}
-
-	public function call($callback)
-	{
-		$this->callback = $callback;
-
-		return $this;
-	}
-
+	// Merge multiple settings from array
 	public function merge(array $data = [])
 	{
 		foreach ($data as $key => $val) $this->$key = $val;
 	}
 
+	// Apply the filter to a request
 	public function filter(Request $request)
 	{
 		return $this->passErrorsOnly($request)
@@ -60,4 +45,14 @@ class ShouldRecord
 
 		return $this->callback($request);
 	}
+
+	// Fluent API
+ 	public function __call($method, $parameters)
+ 	{
+ 		if (! count($parameters)) return $this->$method;
+
+ 		$this->$method = count($parameters) ? $parameters[0] : true;
+
+ 		return $this;
+ 	}
 }

--- a/Clockwork/Support/Laravel/config/clockwork.php
+++ b/Clockwork/Support/Laravel/config/clockwork.php
@@ -133,6 +133,7 @@ return [
 	| requests here.
 	|
 	*/
+
 	'requests' => [
 		// With on-demand mode enabled, Clockwork will only profile requests when the browser extension is open or you
 		// manually pass a "clockwork-profile" cookie or get/post data key.

--- a/Clockwork/Support/Laravel/config/clockwork.php
+++ b/Clockwork/Support/Laravel/config/clockwork.php
@@ -126,6 +126,48 @@ return [
 
 	/*
 	|--------------------------------------------------------------------------
+	| HTTP requests collection
+	|--------------------------------------------------------------------------
+	|
+	| You can enable or disable and configure collection of received HTTP
+	| requests here.
+	|
+	*/
+	'requests' => [
+		// With on-demand mode enabled, Clockwork will only profile requests when the browser extension is open or you
+		// manually pass a "clockwork-profile" cookie or get/post data key.
+		// Optionally you can specify a "secret" that has to be passed as the value to enable profiling.
+		'on_demand' => env('CLOCKWORK_REQUESTS_ON_DEMAND', false),
+
+		// Collect only errors (requests with HTTP 4xx and 5xx responses)
+		'errors_only' => env('CLOCKWORK_REQUESTS_ERRORS_ONLY', false),
+
+		// Response time threshold in miliseconds after which the request will be marked as slow
+		'slow_threshold' => env('CLOCKWORK_REQUESTS_SLOW_THRESHOLD'),
+
+		// Collect only slow requests
+		'slow_only' => env('CLOCKWORK_REQUESTS_SLOW_ONLY', false),
+
+		// Sample the collected requests (eg. set to 100 to collect only 1 in 100 requests)
+		'sample' => env('CLOCKWORK_REQUESTS_SAMPLE', false),
+
+		// List of URIs that should not be collected
+		'except' => [
+			'/horizon/.*', // Laravel Horizon requests
+			'/telescope/.*' // Laravel Telescope requests
+		],
+
+		// List of URIs that should be collected, any other URI will not be collected if not empty
+		'only' => [
+			// '/api/.*'
+		],
+
+		// Don't collect OPTIONS requests, mostly used in the CSRF pre-flight requests and are rarely of interest
+		'except_preflight' => env('CLOCKWORK_REQUESTS_EXCEPT_PREFLIGHT', true)
+	],
+
+	/*
+	|--------------------------------------------------------------------------
 	| Artisan commands collection
 	|--------------------------------------------------------------------------
 	|
@@ -270,47 +312,6 @@ return [
 	'authentication' => env('CLOCKWORK_AUTHENTICATION', false),
 
 	'authentication_password' => env('CLOCKWORK_AUTHENTICATION_PASSWORD', 'VerySecretPassword'),
-
-	/*
-	|--------------------------------------------------------------------------
-	| On-demand mode
-	|--------------------------------------------------------------------------
-	|
-	| With on-demand mode enabled, Clockwork will only profile requests when
-	| the browser extension is open or you manually pass a "clockwork-profile"
-	| cookie or get/post data key.
-	| Optionally you can specify a secret value that has to be also passed
-	| to enable profiling.
-	|
-	*/
-
-	'on_demand' => [
-		// Enable or disable the on-demand mode
-		'enabled' => env('CLOCKWORK_ON_DEMAND_ENABLED', false),
-
-		// Secret that has to be provided to enable profiling in on-demand mode (none by default)
-		'secret' => env('CLOCKWORK_ON_DEMAND_SECRET', null)
-	],
-
-	/*
-	|--------------------------------------------------------------------------
-	| Disable data collection for certain URIs or methods
-	|--------------------------------------------------------------------------
-	|
-	| You can disable data collection for specific URIs by adding matching
-	| regular expressions here. You can also disable collecting all requests
-	| with a specific method.
-	|
-	*/
-
-	'filter_uris' => [
-		'/horizon/.*', // Laravel Horizon requests
-		'/telescope/.*' // Laravel Telescope requests
-	],
-
-	'filter_methods' => [
-		'options' // mostly used in the csrf pre-flight requests and is rarely of interest
-	],
 
 	/*
 	|--------------------------------------------------------------------------

--- a/Clockwork/Support/Vanilla/config.php
+++ b/Clockwork/Support/Vanilla/config.php
@@ -17,6 +17,48 @@ return [
 
 	/*
 	|--------------------------------------------------------------------------
+	| HTTP requests collection
+	|--------------------------------------------------------------------------
+	|
+	| You can enable or disable and configure collection of received HTTP
+	| requests here.
+	|
+	*/
+
+	'requests' => [
+		// With on-demand mode enabled, Clockwork will only profile requests when the browser extension is open or you
+		// manually pass a "clockwork-profile" cookie or get/post data key.
+		// Optionally you can specify a "secret" that has to be passed as the value to enable profiling.
+		'on_demand' => isset($_ENV['CLOCKWORK_REQUESTS_ON_DEMAND']) ? $_ENV['CLOCKWORK_REQUESTS_ON_DEMAND'] : false,
+
+		// Collect only errors (requests with HTTP 4xx and 5xx responses)
+		'errors_only' => isset($_ENV['CLOCKWORK_REQUESTS_ERRORS_ONLY']) ? $_ENV['CLOCKWORK_REQUESTS_ERRORS_ONLY'] : false,
+
+		// Response time threshold in miliseconds after which the request will be marked as slow
+		'slow_threshold' => isset($_ENV['CLOCKWORK_REQUESTS_SLOW_THRESHOLD']) ? $_ENV['CLOCKWORK_REQUESTS_SLOW_THRESHOLD'] : null,
+
+		// Collect only slow requests
+		'slow_only' => isset($_ENV['CLOCKWORK_REQUESTS_SLOW_ONLY']) ? $_ENV['CLOCKWORK_REQUESTS_SLOW_ONLY'] : false,
+
+		// Sample the collected requests (eg. set to 100 to collect only 1 in 100 requests)
+		'sample' => isset($_ENV['CLOCKWORK_REQUESTS_SAMPLE']) ? $_ENV['CLOCKWORK_REQUESTS_SAMPLE'] : false,
+
+		// List of URIs that should not be collected
+		'except' => [
+			// '/api/.*'
+		],
+
+		// List of URIs that should be collected, any other URI will not be collected if not empty
+		'only' => [
+			// '/api/.*'
+		],
+
+		// Don't collect OPTIONS requests, mostly used in the CSRF pre-flight requests and are rarely of interest
+		'except_preflight' => isset($_ENV['CLOCKWORK_REQUESTS_EXCEPT_PREFLIGHT']) ? $_ENV['CLOCKWORK_REQUESTS_EXCEPT_PREFLIGHT'] : true
+	],
+
+	/*
+	|--------------------------------------------------------------------------
 	| Enable data collection, when Clockwork is disabled
 	|--------------------------------------------------------------------------
 	|


### PR DESCRIPTION
- reworked how we check whether request should be collected and recorded
- added option to collect errors only (requests with HTTP 4xx and 5xx responses)
- added option to specify slow threshold and collect only slow requests
- added option to sample requests (collect 1 in X requests)
- added ability to filter collected and recorded requests by a closure

## docs

- a closure with arbitrary logic can now be used to filter collected and recorded requests
    - shouldCollect callback is checked at the start of the request before any data is collected
    - shouldRecord callback is checked at the end of the request before data is stored (and have full access to the collected data)

```php
// collect all requests in local environment, only POST requests otherwise
clock()->shouldCollect(function () {
    if (app()->environment('local')) return true;

    return request()->getMethod() == 'POST';
});

// record only requests from authenticated users
clock()->shouldRecord(function ($request) {
    return $request->authenticatedUser;
});
```

- default collecting settings can also be changed programatically via a fluent API or array-based API

```php
// use the fluent API to add an except url
clock()->shouldCollect()->except('/api/.*');

// use the array-based API to enable collecting errors only
clock()->shouldCollect([ 'errorsOnly' => true ]);
```

## breaking

- the `filter_uris` setting was replaced by `requests.except`
- the `filter_methods` setting was dropped in favor of more specific `requests.except_preflight` setting
- the `on_demand.enabled` and `on_demand.secret` settings were merged into a single `requests.on_demand` setting