### PR TITLE
Collect notifications

### DIFF
--- a/Clockwork/DataSource/LaravelNotificationsDataSource.php
+++ b/Clockwork/DataSource/LaravelNotificationsDataSource.php
@@ -1,0 +1,202 @@
+<?php namespace Clockwork\DataSource;
+
+use Clockwork\Helpers\Serializer;
+use Clockwork\Helpers\StackTrace;
+use Clockwork\Request\Request;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Events\MessageSent;
+use Illuminate\Notifications\Events\NotificationSent;
+
+// Data source for Laravel notifications and mail components, provides sent notifications and emails
+class LaravelNotificationsDataSource extends DataSource
+{
+	// Event dispatcher
+	protected $dispatcher;
+
+	// Sent notifications
+	protected $notifications = [];
+
+	// Create a new data source instance, takes an event dispatcher as argument
+	public function __construct(Dispatcher $dispatcher)
+	{
+		$this->dispatcher = $dispatcher;
+	}
+
+	// Start listening to the events
+	public function listenToEvents()
+	{
+		$this->dispatcher->listen(MessageSent::class, function ($event) { $this->registerMessage($event); });
+		$this->dispatcher->listen(NotificationSent::class, function ($event) { $this->registerNotification($event); });
+	}
+
+	// Add sent notifications to the request
+	public function resolve(Request $request)
+	{
+		$request->notifications = array_merge($request->notifications, $this->notifications);
+
+		return $request;
+	}
+
+	// Reset the data source to an empty state, clearing any collected data
+	public function reset()
+	{
+		$this->notifications = [];
+	}
+
+	// Register a sent email
+	protected function registerMessage($event)
+	{
+		$trace = StackTrace::get()->resolveViewName();
+
+		$mailable = ($frame = $trace->first(function ($frame) { return is_subclass_of($frame->object, Mailable::class); }))
+			? $frame->object : null;
+
+		$notification = [
+			'subject' => $event->message->getSubject(),
+			'from'    => $this->messageAddressToString($event->message->getFrom()),
+			'to'      => $this->messageAddressToString($event->message->getTo()),
+			'content' => $event->message->getBody(),
+			'type'    => 'mail',
+			'data'    => [
+				'cc'       => $this->messageAddressToString($event->message->getCc()),
+				'bcc'      => $this->messageAddressToString($event->message->getBcc()),
+				'replyTo'  => $this->messageAddressToString($event->message->getReplyTo()),
+				'mailable' => (new Serializer)->normalize($mailable)
+			],
+			'time'    => microtime(true),
+			'trace'   => $shortTrace = (new Serializer)->trace($trace),
+			'file'    => isset($shortTrace[0]) ? $shortTrace[0]['file'] : null,
+			'line'    => isset($shortTrace[0]) ? $shortTrace[0]['line'] : null
+		];
+
+		if ($this->passesFilters([ $notification ])) {
+			$this->notifications[] = $notification;
+		}
+	}
+
+	// Register a sent notification
+	protected function registerNotification($event)
+	{
+		$trace = StackTrace::get()->resolveViewName();
+
+		$channelSpecific = $this->resolveChannelSpecific($event);
+
+		$notification = [
+			'subject' => $channelSpecific['subject'],
+			'from'    => $channelSpecific['from'],
+			'to'      => $channelSpecific['to'],
+			'content' => $channelSpecific['content'],
+			'type'    => $event->channel,
+			'data'    => (new Serializer)->normalizeEach(array_merge($channelSpecific['data'], [
+				'notification' => $event->notification,
+				'notifiable'   => $event->notifiable,
+				'response'     => $event->response
+			])),
+			'time'    => microtime(true),
+			'trace'   => $shortTrace = (new Serializer)->trace($trace),
+			'file'    => isset($shortTrace[0]) ? $shortTrace[0]['file'] : null,
+			'line'    => isset($shortTrace[0]) ? $shortTrace[0]['line'] : null
+		];
+
+		if ($event->channel == 'mail') {
+			if ($this->updateLastEmailNotification($notification)) return;
+		}
+
+		if ($this->passesFilters([ $notification ])) {
+			$this->notifications[] = $notification;
+		}
+	}
+
+	// Update last sent email notification with additional data from the notification event
+	protected function updateLastEmailNotification($notification)
+	{
+		$lastIndex = count($this->notifications) - 1;
+		$lastNotification = $this->notifications[$lastIndex];
+
+		if (implode($lastNotification['to']) != implode($notification['to'])) return false;
+
+		$this->notifications[$lastIndex]['data'] = array_merge($lastNotification['data'], $notification['data']);
+
+		return true;
+	}
+
+	// Resolve notification channnel specific data
+	protected function resolveChannelSpecific($event)
+	{
+		if (method_exists($event->notification, 'toMail')) {
+			$channelSpecific = $this->resolveMailChannelSpecific($event, $event->notification->toMail($event->notifiable));
+		} elseif (method_exists($event->notification, 'toSlack')) {
+			$channelSpecific = $this->resolveSlackChannelSpecific($event, $event->notification->toSlack($event->notifiable));
+		} elseif (method_exists($event->notification, 'toNexmo')) {
+			$channelSpecific = $this->resolveNexmoChannelSpecific($event, $event->notification->toNexmo($event->notifiable));
+		} elseif (method_exists($event->notification, 'toBroadcast')) {
+			$channelSpecific = [ 'data' => $event->notification->toBroadcast($event->notifiable)->data ];
+		} else {
+			$channelSpecific = [ 'data' => $event->notification->toArray() ];
+		}
+
+		return array_merge(
+			[ 'subject' => null, 'from' => null, 'to' => null, 'content' => null, 'data' => [] ], $channelSpecific
+		);
+	}
+
+	// Resolve mail notification channel specific data
+	protected function resolveMailChannelSpecific($event, $message)
+	{
+		return [
+			'subject' => $message->subject ?: get_class($event->notification),
+			'from'    => $this->notificationAddressToString($message->from),
+			'to'      => $this->notificationAddressToString($event->notifiable->routeNotificationFor('mail', $event->notification)),
+			'data'    => [
+				'cc'      => $this->notificationAddressToString($message->cc),
+				'bcc'     => $this->notificationAddressToString($message->bcc),
+				'replyTo' => $this->notificationAddressToString($message->replyTo)
+			]
+		];
+	}
+
+	// Resolve Slack notification channel specific data
+	protected function resolveSlackChannelSpecific($event, $message)
+	{
+		return [
+			'subject' => $message->subject ?: get_class($event->notification),
+			'from'    => $message->username,
+			'to'      => $message->channel,
+			'content' => $message->content
+		];
+	}
+
+	// Resolve Nexmo notification channel specific data
+	protected function resolveNexmoChannelSpecific($event, $message)
+	{
+		return [
+			'subject' => $message->subject ?: get_class($event->notification),
+			'from'    => $message->from,
+			'to'      => $event->notifiable->routeNotificationFor('nexmo', $event->notification),
+			'content' => $message->content
+		];
+	}
+
+	protected function messageAddressToString($address)
+	{
+		if (! $address) return;
+
+		return array_map(function ($name, $email) {
+			return $name ? "{$name} <{$email}>" : $email;
+		}, $address, array_keys($address));
+	}
+
+	protected function notificationAddressToString($address)
+	{
+		if (! $address) return;
+		if (! is_array($address)) $address = [ $address ];
+
+		return array_map(function ($address) {
+			if (! is_array($address)) return $address;
+
+			return $address[1] ? "{$address[1]} <{$address[0]}>" : $address[0];
+		}, $address);
+	}
+}

--- a/Clockwork/DataSource/SwiftDataSource.php
+++ b/Clockwork/DataSource/SwiftDataSource.php
@@ -11,6 +11,8 @@ use Swift_Mailer;
  */
 class SwiftDataSource extends DataSource
 {
+	protected $swift;
+
 	/**
 	 * Timeline data structure
 	 */
@@ -21,9 +23,14 @@ class SwiftDataSource extends DataSource
 	 */
 	public function __construct(Swift_Mailer $swift)
 	{
-		$this->timeline = new Timeline();
+		$this->swift = $swift;
+		$this->timeline = new Timeline;
+	}
 
-		$swift->registerPlugin(new SwiftPluginClockworkTimeline($this->timeline));
+	// Start listening to the events
+	public function listenToEvents()
+	{
+		$this->swift->registerPlugin(new SwiftPluginClockworkTimeline($this->timeline));
 	}
 
 	/**

--- a/Clockwork/Request/Request.php
+++ b/Clockwork/Request/Request.php
@@ -178,6 +178,9 @@ class Request
 	 */
 	public $routes = [];
 
+	// Sent notifications
+	public $notifications = [];
+
 	/**
 	 * Emails data array
 	 */
@@ -343,6 +346,7 @@ class Request
 			'log'                      => array_values($this->log),
 			'events'                   => $this->events,
 			'routes'                   => $this->routes,
+			'notifications'            => $this->notifications,
 			'emailsData'               => $this->emailsData,
 			'viewsData'                => $this->viewsData,
 			'userData'                 => array_map(function ($data) {
@@ -475,6 +479,23 @@ class Request
 			'middleware' => isset($data['middleware']) ? $data['middleware'] : null,
 			'before'     => isset($data['before']) ? $data['before'] : null,
 			'after'      => isset($data['after']) ? $data['after'] : null
+		];
+	}
+
+	// Add sent notifucation, takes subject, recipient, sender, and additional data - time, duration, type, content, data
+	public function addNotification($subject, $to, $from = null, $data = [])
+	{
+		$this->notifications[] = [
+			'subject' => $subject,
+			'from'    => $from,
+			'to'      => $to,
+			'content' => isset($data['content']) ? $data['content'] : null,
+			'type'    => isset($data['type']) ? $data['type'] : null,
+			'data'    => isset($data['data']) ? $data['data'] : [],
+			'time'    => isset($data['time']) ? $data['time'] : microtime(true),
+			'trace'   => isset($data['trace']) ? $data['trace'] : null,
+			'file'    => isset($data['file']) ? $data['file'] : null,
+			'line'    => isset($data['line']) ? $data['line'] : null
 		];
 	}
 

--- a/Clockwork/Storage/SqlStorage.php
+++ b/Clockwork/Storage/SqlStorage.php
@@ -67,6 +67,7 @@ class SqlStorage extends Storage
 		'log'                      => 'TEXT NULL',
 		'events'                   => 'TEXT NULL',
 		'routes'                   => 'TEXT NULL',
+		'notifications'            => 'TEXT NULL',
 		'emailsData'               => 'TEXT NULL',
 		'viewsData'                => 'TEXT NULL',
 		'userData'                 => 'TEXT NULL',
@@ -97,8 +98,8 @@ class SqlStorage extends Storage
 	protected $needsSerialization = [
 		'headers', 'getData', 'postData', 'requestData', 'sessionData', 'authenticatedUser', 'cookies', 'middleware',
 		'databaseQueries', 'cacheQueries', 'modelsActions', 'modelsRetrieved', 'modelsCreated', 'modelsUpdated',
-		'modelsDeleted', 'redisCommands', 'queueJobs', 'timelineData', 'log', 'events', 'routes', 'emailsData',
-		'viewsData', 'userData', 'subrequests', 'xdebug', 'commandArguments', 'commandArgumentsDefaults',
+		'modelsDeleted', 'redisCommands', 'queueJobs', 'timelineData', 'log', 'events', 'routes', 'notifications',
+		'emailsData', 'viewsData', 'userData', 'subrequests', 'xdebug', 'commandArguments', 'commandArgumentsDefaults',
 		'commandOptions', 'commandOptionsDefaults', 'jobPayload', 'jobOptions', 'testAsserts', 'parent'
 	];
 

--- a/Clockwork/Support/Laravel/ClockworkSupport.php
+++ b/Clockwork/Support/Laravel/ClockworkSupport.php
@@ -373,6 +373,9 @@ class ClockworkSupport
 	{
 		if ($feature == 'database') {
 			return $this->app['config']->get('database.default');
+		} elseif ($feature == 'notifications-events') {
+			return class_exists(\Illuminate\Mail\Events\MessageSent::class)
+				&& class_exists(\Illuminate\Notifications\Events\NotificationSent::class);
 		} elseif ($feature == 'redis') {
 			return method_exists(\Illuminate\Redis\RedisManager::class, 'enableEvents');
 		} elseif ($feature == 'queue') {

--- a/Clockwork/Support/Laravel/config/clockwork.php
+++ b/Clockwork/Support/Laravel/config/clockwork.php
@@ -61,11 +61,6 @@ return [
 			'detect_duplicate_queries' => env('CLOCKWORK_DATABASE_DETECT_DUPLICATE_QUERIES', false)
 		],
 
-		// Sent emails
-		'emails' => [
-			'enabled' => env('CLOCKWORK_EMAILS_ENABLED', true),
-		],
-
 		// Dispatched events
 		'events' => [
 			'enabled' => env('CLOCKWORK_EVENTS_ENABLED', true),
@@ -80,6 +75,11 @@ return [
 		// Laravel log (you can still log directly to Clockwork with laravel log disabled)
 		'log' => [
 			'enabled' => env('CLOCKWORK_LOG_ENABLED', true)
+		],
+
+		// Sent notifications
+		'notifications' => [
+			'enabled' => env('CLOCKWORK_NOTIFICATIONS_ENABLED', true),
 		],
 
 		// Dispatched queue jobs


### PR DESCRIPTION
- added support for collecting notifications (eg. emails, sms, slack messages, etc.)
- notifications api is now the preferred way to collect emails (but original emailData api is still supported)
- new api will be automatically used on supported Laravel versions
- https://github.com/underground-works/clockwork-app/pull/52

## breaking

- the `features.emails` setting was renamed to `features.notifications`
- if you are manually setting `emailsData` on request, consider moving to `notifications`