### PR TITLE
Client-side metrics

### DIFF
--- a/Clockwork/Request/Request.php
+++ b/Clockwork/Request/Request.php
@@ -400,11 +400,17 @@ class Request
 	// Return request data except specified keys as an array
 	public function except($keys)
 	{
-		$data = $this->toArray();
+		return array_filter($this->toArray(), function ($value, $key) use ($keys) {
+			return ! in_array($key, $keys);
+		}, ARRAY_FILTER_USE_BOTH);
+	}
 
-		foreach ($keys as $key) unset($data[$key]);
-
-		return $data;
+	// Return only request data with specified keys as an array
+	public function only($keys)
+	{
+		return array_filter($this->toArray(), function ($value, $key) use ($keys) {
+			return in_array($key, $keys);
+		}, ARRAY_FILTER_USE_BOTH);
 	}
 
 	// Return timeline instance for the current request

--- a/Clockwork/Request/Request.php
+++ b/Clockwork/Request/Request.php
@@ -254,8 +254,17 @@ class Request
 	// Ran test asserts
 	public $testAsserts = [];
 
+	// Client-side performance metrics in the form of [ metric => value ]
+	public $clientMetrics = [];
+
+	// Web vitals in the form of [ vital => value ]
+	public $webVitals = [];
+
 	// Parent request
 	public $parent;
+
+	// Token to update this request data
+	public $updateToken;
 
 	// Timeline instance for the current request
 	protected $currentTimeline;
@@ -268,6 +277,7 @@ class Request
 	{
 		$this->id = isset($data['id']) ? $data['id'] : $this->generateRequestId();
 		$this->time = microtime(true);
+		$this->updateToken = isset($data['updateToken']) ? $data['updateToken'] : $this->generateUpdateToken();
 
 		foreach ($data as $key => $val) {
 			$this->$key = $val;
@@ -372,7 +382,10 @@ class Request
 			'testStatus'               => $this->testStatus,
 			'testStatusMessage'        => $this->testStatusMessage,
 			'testAsserts'              => $this->testAsserts,
-			'parent'                   => $this->parent
+			'clientMetrics'            => $this->clientMetrics,
+			'webVitals'                => $this->webVitals,
+			'parent'                   => $this->parent,
+			'updateToken'              => $this->updateToken
 		];
 	}
 
@@ -382,6 +395,16 @@ class Request
 	public function toJson()
 	{
 		return json_encode($this->toArray(), \JSON_PARTIAL_OUTPUT_ON_ERROR);
+	}
+
+	// Return request data except specified keys as an array
+	public function except($keys)
+	{
+		$data = $this->toArray();
+
+		foreach ($keys as $key) unset($data[$key]);
+
+		return $data;
 	}
 
 	// Return timeline instance for the current request
@@ -592,5 +615,14 @@ class Request
 	protected function generateRequestId()
 	{
 		return str_replace('.', '-', sprintf('%.4F', microtime(true))) . '-' . mt_rand();
+	}
+
+	// Generate a random update token
+	protected function generateUpdateToken()
+	{
+		$length = 8;
+		$bytes = function_exists('random_bytes') ? random_bytes($length) : openssl_random_pseudo_bytes($length);
+
+		return substr(bin2hex($bytes), 0, $length);
 	}
 }

--- a/Clockwork/Storage/FileStorage.php
+++ b/Clockwork/Storage/FileStorage.php
@@ -80,7 +80,7 @@ class FileStorage extends Storage
 	}
 
 	// Store request, requests are stored in JSON representation in files named <request id>.json in storage path
-	public function store(Request $request)
+	public function store(Request $request, $skipIndex = false)
 	{
 		$path = "{$this->path}/{$request->id}.json";
 		$data = @json_encode($request->toArray(), \JSON_PARTIAL_OUTPUT_ON_ERROR);
@@ -89,8 +89,15 @@ class FileStorage extends Storage
 			? file_put_contents("{$path}.gz", gzcompress($data))
 			: file_put_contents($path, $data);
 
-		$this->updateIndex($request);
+		if (! $skipIndex) $this->updateIndex($request);
+
 		$this->cleanup();
+	}
+
+	// Update existing request
+	public function update(Request $request)
+	{
+		return $this->store($request, true);
 	}
 
 	// Cleanup old requests

--- a/Clockwork/Support/Laravel/ClockworkController.php
+++ b/Clockwork/Support/Laravel/ClockworkController.php
@@ -40,6 +40,13 @@ class ClockworkController extends Controller
 		return $this->app['clockwork.support']->getExtendedData($id);
 	}
 
+	public function updateData($id = null)
+	{
+		$this->ensureClockworkIsEnabled();
+
+		return $this->app['clockwork.support']->updateData($id, $this->app['request']->json()->all());
+	}
+
 	public function webIndex()
 	{
 		$this->ensureClockworkIsEnabled();

--- a/Clockwork/Support/Laravel/ClockworkController.php
+++ b/Clockwork/Support/Laravel/ClockworkController.php
@@ -30,14 +30,18 @@ class ClockworkController extends Controller
 	{
 		$this->ensureClockworkIsEnabled();
 
-		return $this->app['clockwork.support']->getData($id, $direction, $count);
+		return $this->app['clockwork.support']->getData(
+			$id, $direction, $count, $this->app['request']->only([ 'only', 'except' ])
+		);
 	}
 
 	public function getExtendedData($id = null)
 	{
 		$this->ensureClockworkIsEnabled();
 
-		return $this->app['clockwork.support']->getExtendedData($id);
+		return $this->app['clockwork.support']->getExtendedData(
+			$id, $this->app['request']->only([ 'only', 'except' ])
+		);
 	}
 
 	public function updateData($id = null)

--- a/Clockwork/Support/Laravel/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Laravel/ClockworkServiceProvider.php
@@ -302,6 +302,7 @@ class ClockworkServiceProvider extends ServiceProvider
 			->where('id', '([0-9-]+|latest)');
 		$this->app['router']->get('/__clockwork/{id}/{direction?}/{count?}', 'Clockwork\Support\Laravel\ClockworkController@getData')
 			->where('id', '([0-9-]+|latest)')->where('direction', '(next|previous)')->where('count', '\d+');
+		$this->app['router']->put('/__clockwork/{id}', 'Clockwork\Support\Laravel\ClockworkController@updateData');
 		$this->app['router']->post('/__clockwork/auth', 'Clockwork\Support\Laravel\ClockworkController@authenticate');
 	}
 

--- a/Clockwork/Support/Laravel/config/clockwork.php
+++ b/Clockwork/Support/Laravel/config/clockwork.php
@@ -82,6 +82,12 @@ return [
 			'enabled' => env('CLOCKWORK_NOTIFICATIONS_ENABLED', true),
 		],
 
+		// Performance metrics
+		'performance' => [
+			// Allow collecting of client metrics. Requires separate clockwork-browser npm package.
+			'client_metrics' => env('CLOCKWORK_PERFORMANCE_CLIENT_METRICS', true)
+		],
+
 		// Dispatched queue jobs
 		'queue' => [
 			'enabled' => env('CLOCKWORK_QUEUE_ENABLED', true)

--- a/Clockwork/Support/Lumen/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Lumen/ClockworkServiceProvider.php
@@ -105,6 +105,7 @@ class ClockworkServiceProvider extends LaravelServiceProvider
 
 		$router->get('/__clockwork/{id:(?:[0-9-]+|latest)}/extended', 'Clockwork\Support\Lumen\Controller@getExtendedData');
 		$router->get('/__clockwork/{id:(?:[0-9-]+|latest)}[/{direction:(?:next|previous)}[/{count:\d+}]]', 'Clockwork\Support\Lumen\Controller@getData');
+		$router->put('/__clockwork/{id}', 'Clockwork\Support\Lumen\Controller@updateData');
 		$router->post('/__clockwork/auth', 'Clockwork\Support\Lumen\Controller@authenticate');
 	}
 

--- a/Clockwork/Support/Lumen/Controller.php
+++ b/Clockwork/Support/Lumen/Controller.php
@@ -45,6 +45,13 @@ class Controller extends LumenController
 		return $this->clockworkSupport->getExtendedData($id);
 	}
 
+	public function updateData(Request $request, $id = null)
+	{
+		$this->ensureClockworkIsEnabled();
+
+		return $this->clockworkSupport->updateData($id, $request->json()->all());
+	}
+
 	public function webIndex(Request $request)
 	{
 		$this->ensureClockworkIsEnabled();

--- a/Clockwork/Support/Lumen/Controller.php
+++ b/Clockwork/Support/Lumen/Controller.php
@@ -31,18 +31,22 @@ class Controller extends LumenController
 		return new JsonResponse([ 'token' => $token ], $token ? 200 : 403);
 	}
 
-	public function getData($id = null, $direction = null, $count = null)
+	public function getData(Request $request, $id = null, $direction = null, $count = null)
 	{
 		$this->ensureClockworkIsEnabled();
 
-		return $this->clockworkSupport->getData($id, $direction, $count);
+		return $this->clockworkSupport->getData(
+			$id, $direction, $count, $request->only([ 'only', 'except' ])
+		);
 	}
 
-	public function getExtendedData($id = null)
+	public function getExtendedData(Request $request, $id = null)
 	{
 		$this->ensureClockworkIsEnabled();
 
-		return $this->clockworkSupport->getExtendedData($id);
+		return $this->clockworkSupport->getExtendedData(
+			$id, $request->only([ 'only', 'except' ])
+		);
 	}
 
 	public function updateData(Request $request, $id = null)


### PR DESCRIPTION
- added support for collecting client-side metrics
    - client metrics - include basic metrics obtainable by the Navigation Timing browser api like DNS, waiting and receiving times and DOM to interactive and to complete timings (https://developer.mozilla.org/en-US/docs/Web/API/Navigation_timing_API)
    - web vitals - set of performance metrics defined by Google (https://web.dev/vitals/)
- added ability to update existing request metadata
    - all requests now have an update token generated
    - new Clockwork HTTP api route for updating metadata
    - requires passing correct update token, only client metrics are updatable atm
    - update token is not returned when retrieving requests via Clockwork HTTP api
    - only active if client metrics collection is enabled
- collecting the metrics requires a client-side component
    - https://github.com/underground-works/clockwork-browser
    - will be available via npm and cdn on release
    - the update token and request id are passed to browser via cookies
- added config option to enable collecting of client-metrics (default enabled)
- added support for only and except parameters to the retrieve request Clockwork HTTP api
- app https://github.com/underground-works/clockwork-app/pull/55
