### PR TITLE
Toolbar

### DIFF
--- a/Clockwork/Support/Laravel/ClockworkSupport.php
+++ b/Clockwork/Support/Laravel/ClockworkSupport.php
@@ -446,7 +446,7 @@ class ClockworkSupport
 
 	public function isCollectingClientMetrics()
 	{
-		return $this->getConfig('performance.client_metrics', true);
+		return $this->getConfig('features.performance.client_metrics', true);
 	}
 
 	public function isToolbarEnabled()

--- a/Clockwork/Support/Laravel/ClockworkSupport.php
+++ b/Clockwork/Support/Laravel/ClockworkSupport.php
@@ -308,15 +308,19 @@ class ClockworkSupport
 			return $response;
 		}
 
-		$clockworkRequest = $this->app['clockwork']->getRequest();
-
 		if ($this->isCollectingClientMetrics() || $this->isToolbarEnabled()) {
-			$response->cookie('clockwork_id', $clockworkRequest->id, 60, null, null, null, false);
-			$response->cookie('clockwork_version', Clockwork::VERSION, 60, null, null, null, false);
-			$response->cookie('clockwork_path', $request->getBasePath() . '/__clockwork/', 60, null, null, null, false);
-			$response->cookie('clockwork_token', $clockworkRequest->updateToken, 60, null, null, null, false);
-			$response->cookie('clockwork_metrics', $this->isCollectingClientMetrics() ? 1 : 0, 60, null, null, null, false);
-			$response->cookie('clockwork_toolbar', $this->isToolbarEnabled() ? 1 : 0, 60, null, null, null, false);
+			$clockworkRequest = $this->app['clockwork']->getRequest();
+
+			$clockworkBrowser = [
+				'requestId' => $clockworkRequest->id,
+				'version'   => Clockwork::VERSION,
+				'path'      => $request->getBasePath() . '/__clockwork/',
+				'token'     => $clockworkRequest->updateToken,
+				'metrics'   => $this->isCollectingClientMetrics(),
+				'toolbar'   => $this->isToolbarEnabled()
+			];
+
+			$response->cookie('x-clockwork', json_encode($clockworkBrowser), 60, null, null, null, false);
 		}
 
 		return $response;

--- a/Clockwork/Support/Laravel/ClockworkSupport.php
+++ b/Clockwork/Support/Laravel/ClockworkSupport.php
@@ -362,7 +362,8 @@ class ClockworkSupport
 		]);
 
 		// don't collect data for Clockwork requests
-		$this->app['clockwork']->shouldCollect()->except('/__clockwork(?:/.*)?');
+		$webPath = $this->webPaths()[0];
+		$this->app['clockwork']->shouldCollect()->except([ '/__clockwork(?:/.*)?', "/{$webPath}(?:/.*)?" ]);
 
 		return $this;
 	}

--- a/Clockwork/Support/Laravel/ClockworkSupport.php
+++ b/Clockwork/Support/Laravel/ClockworkSupport.php
@@ -304,13 +304,19 @@ class ClockworkSupport
 
 		$this->appendServerTimingHeader($response, $this->app['clockwork']->getRequest());
 
+		if (! ($response instanceof Response)) {
+			return $response;
+		}
+
 		$clockworkRequest = $this->app['clockwork']->getRequest();
 
-		if ($this->isCollectingClientMetrics() && $response instanceof Response) {
+		if ($this->isCollectingClientMetrics() || $this->isToolbarEnabled()) {
 			$response->cookie('clockwork_id', $clockworkRequest->id, 60, null, null, null, false);
 			$response->cookie('clockwork_version', Clockwork::VERSION, 60, null, null, null, false);
 			$response->cookie('clockwork_path', $request->getBasePath() . '/__clockwork/', 60, null, null, null, false);
 			$response->cookie('clockwork_token', $clockworkRequest->updateToken, 60, null, null, null, false);
+			$response->cookie('clockwork_metrics', $this->isCollectingClientMetrics() ? 1 : 0, 60, null, null, null, false);
+			$response->cookie('clockwork_toolbar', $this->isToolbarEnabled() ? 1 : 0, 60, null, null, null, false);
 		}
 
 		return $response;
@@ -441,6 +447,11 @@ class ClockworkSupport
 	public function isCollectingClientMetrics()
 	{
 		return $this->getConfig('performance.client_metrics', true);
+	}
+
+	public function isToolbarEnabled()
+	{
+		return $this->getConfig('toolbar', false);
 	}
 
 	public function isWebEnabled()

--- a/Clockwork/Support/Laravel/config/clockwork.php
+++ b/Clockwork/Support/Laravel/config/clockwork.php
@@ -123,12 +123,23 @@ return [
 	|--------------------------------------------------------------------------
 	|
 	| Enable or disable the Clockwork web UI available at  http://your.app/__clockwork.
-	| You can also set whether to use the dark theme by default.
 	| Default: true
 	|
 	*/
 
 	'web' => env('CLOCKWORK_WEB', true),
+
+	/*
+	|--------------------------------------------------------------------------
+	| Enable toolbar
+	|--------------------------------------------------------------------------
+	|
+	| Enable or disable the Clockwork toolbar. Requires a separate clockwork-browser npm package.
+	| Default: false
+	|
+	*/
+
+	'toolbar' => env('CLOCKWORK_TOOLBAR', false),
 
 	/*
 	|--------------------------------------------------------------------------


### PR DESCRIPTION
- added setting to toggle Clockwork toolbar
- requires an additional clockwork-browser client-side component
    - https://github.com/underground-works/clockwork-browser
    - will be available via npm and cdn on release
    - reworked clockwork-browser payload to use a single cookie with json
- fixed wrong check whether client-metrics are enabled
- fixed requests to default web ui path being collected

<img width="1377" alt="Screenshot 2020-09-14 at 23 31 57" src="https://user-images.githubusercontent.com/821582/93140699-2f4ff600-f6e3-11ea-8c7f-8fa45b5b1e8c.png">
