### PR TITLE
Move recording to a terminate callback

### DIFF
--- a/Clockwork/Support/Laravel/ClockworkMiddleware.php
+++ b/Clockwork/Support/Laravel/ClockworkMiddleware.php
@@ -32,6 +32,11 @@ class ClockworkMiddleware
 			$response = $this->app[ExceptionHandler::class]->render($request, $e);
 		}
 
-		return $this->app['clockwork.support']->process($request, $response);
+		return $this->app['clockwork.support']->processRequest($request, $response);
+	}
+
+	public function terminate()
+	{
+		$this->app['clockwork.support']->recordRequest();
 	}
 }

--- a/Clockwork/Support/Lumen/ClockworkMiddleware.php
+++ b/Clockwork/Support/Lumen/ClockworkMiddleware.php
@@ -32,6 +32,11 @@ class ClockworkMiddleware
 			$response = $this->app[ExceptionHandler::class]->render($request, $e);
 		}
 
-		return $this->app['clockwork.support']->process($request, $response);
+		return $this->app['clockwork.support']->processRequest($request, $response);
+	}
+
+	public function terminate()
+	{
+		$this->app['clockwork.support']->recordRequest();
 	}
 }


### PR DESCRIPTION
- moved recording of the request to a terminate callback in Laravel
- can save up to 50% on response time overhead depending on the amount of collected data