### PR TITLE
chore: Ignore Laravel DebugBar requests by default

### DIFF
--- a/Clockwork/Support/Laravel/config/clockwork.php
+++ b/Clockwork/Support/Laravel/config/clockwork.php
@@ -173,6 +173,7 @@ return [
 		'except' => [
 			'/horizon/.*', // Laravel Horizon requests
 			'/telescope/.*', // Laravel Telescope requests
+			'/_debugbar/.*', // Laravel DebugBar requests
 		],
 
 		// List of URIs that should be collected, any other URI will not be collected if not empty


### PR DESCRIPTION
When you is using clockwork and DebugBar, the clockwork show all request of DebugBar.