### PR TITLE
Slim 4 support

### DIFF
--- a/Clockwork/Support/Slim/ClockworkMiddleware.php
+++ b/Clockwork/Support/Slim/ClockworkMiddleware.php
@@ -6,52 +6,55 @@ use Clockwork\DataSource\PsrMessageDataSource;
 use Clockwork\Storage\FileStorage;
 use Clockwork\Helpers\ServerTiming;
 
-use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Server\RequestHandlerInterface as RequestHandler;
 
+// Slim 4 middleware
 class ClockworkMiddleware
 {
+	protected $app;
 	protected $clockwork;
 	protected $startTime;
 
-	public function __construct($storagePathOrClockwork, $startTime = null)
+	public function __construct($app, $storagePathOrClockwork, $startTime = null)
 	{
+		$this->app = $app;
 		$this->clockwork = $storagePathOrClockwork instanceof Clockwork
 			? $storagePathOrClockwork : $this->createDefaultClockwork($storagePathOrClockwork);
 		$this->startTime = $startTime ?: microtime(true);
 	}
 
-	public function __invoke(Request $request, Response $response, callable $next)
+	public function __invoke(Request $request, RequestHandler $handler)
 	{
-		return $this->process($request, $response, $next);
+		return $this->process($request, $handler);
 	}
 
-	public function process(Request $request, Response $response, callable $next)
+	public function process(Request $request, RequestHandler $handler)
 	{
 		$authUri = '#/__clockwork/auth#';
 		if (preg_match($authUri, $request->getUri()->getPath(), $matches)) {
-			return $this->authenticate($response, $request);
+			return $this->authenticate($request);
 		}
 
 		$clockworkDataUri = '#/__clockwork(?:/(?<id>[0-9-]+))?(?:/(?<direction>(?:previous|next)))?(?:/(?<count>\d+))?#';
 		if (preg_match($clockworkDataUri, $request->getUri()->getPath(), $matches)) {
 			$matches = array_merge([ 'id' => null, 'direction' => null, 'count' => null ], $matches);
-			return $this->retrieveRequest($response, $request, $matches['id'], $matches['direction'], $matches['count']);
+			return $this->retrieveRequest($request, $matches['id'], $matches['direction'], $matches['count']);
 		}
 
-		$response = $next($request, $response);
+		$response = $handler->handle($request);
 
 		return $this->logRequest($request, $response);
 	}
 
-	protected function authenticate(Response $response, Request $request)
+	protected function authenticate(Request $request)
 	{
 		$token = $this->clockwork->getAuthenticator()->attempt($request->getParsedBody());
 
-		return $response->withJson([ 'token' => $token ])->withStatus($token ? 200 : 403);
+		return $this->jsonResponse([ 'token' => $token ], $token ? 200 : 403);
 	}
 
-	protected function retrieveRequest(Response $response, Request $request, $id, $direction, $count)
+	protected function retrieveRequest(Request $request, $id, $direction, $count)
 	{
 		$authenticator = $this->clockwork->getAuthenticator();
 		$storage = $this->clockwork->getStorage();
@@ -59,9 +62,7 @@ class ClockworkMiddleware
 		$authenticated = $authenticator->check(current($request->getHeader('X-Clockwork-Auth')));
 
 		if ($authenticated !== true) {
-			return $response
-				->withJson([ 'message' => $authenticated, 'requires' => $authenticator->requires() ])
-				->withStatus(403);
+			return $this->jsonResponse([ 'message' => $authenticated, 'requires' => $authenticator->requires() ], 403);
 		}
 
 		if ($direction == 'previous') {
@@ -74,12 +75,10 @@ class ClockworkMiddleware
 			$data = $storage->find($id);
 		}
 
-		return $response
-			->withHeader('Content-Type', 'application/json')
-			->withJson($data);
+		return $this->jsonResponse($data);
 	}
 
-	protected function logRequest(Request $request, Response $response)
+	protected function logRequest(Request $request, $response)
 	{
 		$this->clockwork->getTimeline()->finalize($this->startTime);
 		$this->clockwork->addDataSource(new PsrMessageDataSource($request, $response));
@@ -93,7 +92,7 @@ class ClockworkMiddleware
 			->withHeader('X-Clockwork-Id', $clockworkRequest->id)
 			->withHeader('X-Clockwork-Version', Clockwork::VERSION);
 
-		if ($basePath = $request->getUri()->getBasePath()) {
+		if ($basePath = $this->app->getBasePath()) {
 			$response = $response->withHeader('X-Clockwork-Path', $basePath);
 		}
 
@@ -108,5 +107,16 @@ class ClockworkMiddleware
 		$clockwork->setAuthenticator(new NullAuthenticator);
 
 		return $clockwork;
+	}
+
+	protected function jsonResponse($data, $status = 200)
+	{
+		$response = $this->app->getResponseFactory()
+			->createResponse($status)
+			->withHeader('Content-Type', 'application/json');
+
+		$response->getBody()->write(json_encode($data));
+
+		return $response;
 	}
 }

--- a/Clockwork/Support/Slim/Legacy/ClockworkMiddleware.php
+++ b/Clockwork/Support/Slim/Legacy/ClockworkMiddleware.php
@@ -1,61 +1,69 @@
 <?php namespace Clockwork\Support\Slim\Legacy;
 
 use Clockwork\Clockwork;
-use Clockwork\DataSource\PhpDataSource;
-use Clockwork\DataSource\SlimDataSource;
-use Clockwork\Helpers\ServerTiming;
+use Clockwork\Authentication\NullAuthenticator;
+use Clockwork\DataSource\PsrMessageDataSource;
 use Clockwork\Storage\FileStorage;
+use Clockwork\Helpers\ServerTiming;
 
-use Slim\Middleware;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
 
-class ClockworkMiddleware extends Middleware
+// Slim 3 middleware
+class ClockworkMiddleware
 {
-	private $storagePathOrClockwork;
+	protected $clockwork;
+	protected $startTime;
 
-	public function __construct($storagePathOrClockwork)
+	public function __construct($storagePathOrClockwork, $startTime = null)
 	{
-		$this->storagePathOrClockwork = $storagePathOrClockwork;
+		$this->clockwork = $storagePathOrClockwork instanceof Clockwork
+			? $storagePathOrClockwork : $this->createDefaultClockwork($storagePathOrClockwork);
+		$this->startTime = $startTime ?: microtime(true);
 	}
 
-	public function call()
+	public function __invoke(Request $request, Response $response, callable $next)
 	{
-		$this->app->container->singleton('clockwork', function () {
-			if ($this->storagePathOrClockwork instanceof Clockwork) {
-				return $this->storagePathOrClockwork;
-			}
+		return $this->process($request, $response, $next);
+	}
 
-			$clockwork = new Clockwork();
-
-			$clockwork->addDataSource(new PhpDataSource())
-				->addDataSource(new SlimDataSource($this->app))
-				->setStorage(new FileStorage($this->storagePathOrClockwork));
-
-			return $clockwork;
-		});
-
-		$originalLogWriter = $this->app->getLog()->getWriter();
-		$clockworkLogWriter = new ClockworkLogWriter($this->app->clockwork, $originalLogWriter);
-
-		$this->app->getLog()->setWriter($clockworkLogWriter);
+	public function process(Request $request, Response $response, callable $next)
+	{
+		$authUri = '#/__clockwork/auth#';
+		if (preg_match($authUri, $request->getUri()->getPath(), $matches)) {
+			return $this->authenticate($response, $request);
+		}
 
 		$clockworkDataUri = '#/__clockwork(?:/(?<id>[0-9-]+))?(?:/(?<direction>(?:previous|next)))?(?:/(?<count>\d+))?#';
-		if ($this->app->config('debug') && preg_match($clockworkDataUri, $this->app->request()->getPathInfo(), $matches)) {
-			$matches = array_merge([ 'direction' => null, 'count' => null ], $matches);
-			return $this->retrieveRequest($matches['id'], $matches['direction'], $matches['count']);
+		if (preg_match($clockworkDataUri, $request->getUri()->getPath(), $matches)) {
+			$matches = array_merge([ 'id' => null, 'direction' => null, 'count' => null ], $matches);
+			return $this->retrieveRequest($response, $request, $matches['id'], $matches['direction'], $matches['count']);
 		}
 
-		try {
-			$this->next->call();
-			$this->logRequest();
-		} catch (Exception $e) {
-			$this->logRequest();
-			throw $e;
-		}
+		$response = $next($request, $response);
+
+		return $this->logRequest($request, $response);
 	}
 
-	public function retrieveRequest($id = null, $direction = null, $count = null)
+	protected function authenticate(Response $response, Request $request)
 	{
-		$storage = $this->app->clockwork->getStorage();
+		$token = $this->clockwork->getAuthenticator()->attempt($request->getParsedBody());
+
+		return $response->withJson([ 'token' => $token ])->withStatus($token ? 200 : 403);
+	}
+
+	protected function retrieveRequest(Response $response, Request $request, $id, $direction, $count)
+	{
+		$authenticator = $this->clockwork->getAuthenticator();
+		$storage = $this->clockwork->getStorage();
+
+		$authenticated = $authenticator->check(current($request->getHeader('X-Clockwork-Auth')));
+
+		if ($authenticated !== true) {
+			return $response
+				->withJson([ 'message' => $authenticated, 'requires' => $authenticator->requires() ])
+				->withStatus(403);
+		}
 
 		if ($direction == 'previous') {
 			$data = $storage->previous($id, $count);
@@ -67,25 +75,39 @@ class ClockworkMiddleware extends Middleware
 			$data = $storage->find($id);
 		}
 
-		echo json_encode($data, \JSON_PARTIAL_OUTPUT_ON_ERROR);
+		return $response
+			->withHeader('Content-Type', 'application/json')
+			->withJson($data);
 	}
 
-	protected function logRequest()
+	protected function logRequest(Request $request, Response $response)
 	{
-		$this->app->clockwork->resolveRequest();
-		$this->app->clockwork->storeRequest();
+		$this->clockwork->getTimeline()->finalize($this->startTime);
+		$this->clockwork->addDataSource(new PsrMessageDataSource($request, $response));
 
-		if ($this->app->config('debug')) {
-			$this->app->response()->header('X-Clockwork-Id', $this->app->clockwork->getRequest()->id);
-			$this->app->response()->header('X-Clockwork-Version', Clockwork::VERSION);
+		$this->clockwork->resolveRequest();
+		$this->clockwork->storeRequest();
 
-			$env = $this->app->environment();
-			if ($env['SCRIPT_NAME']) {
-				$this->app->response()->header('X-Clockwork-Path', $env['SCRIPT_NAME'] . '/__clockwork/');
-			}
+		$clockworkRequest = $this->clockwork->getRequest();
 
-			$request = $this->app->clockwork->getRequest();
-			$this->app->response()->header('Server-Timing', ServerTiming::fromRequest($request)->value());
+		$response = $response
+			->withHeader('X-Clockwork-Id', $clockworkRequest->id)
+			->withHeader('X-Clockwork-Version', Clockwork::VERSION);
+
+		if ($basePath = $request->getUri()->getBasePath()) {
+			$response = $response->withHeader('X-Clockwork-Path', $basePath);
 		}
+
+		return $response->withHeader('Server-Timing', ServerTiming::fromRequest($clockworkRequest)->value());
+	}
+
+	protected function createDefaultClockwork($storagePath)
+	{
+		$clockwork = new Clockwork();
+
+		$clockwork->setStorage(new FileStorage($storagePath));
+		$clockwork->setAuthenticator(new NullAuthenticator);
+
+		return $clockwork;
 	}
 }

--- a/Clockwork/Support/Slim/Old/ClockworkLogWriter.php
+++ b/Clockwork/Support/Slim/Old/ClockworkLogWriter.php
@@ -1,4 +1,4 @@
-<?php namespace Clockwork\Support\Slim\Legacy;
+<?php namespace Clockwork\Support\Slim\Old;
 
 use Clockwork\Clockwork;
 

--- a/Clockwork/Support/Slim/Old/ClockworkMiddleware.php
+++ b/Clockwork/Support/Slim/Old/ClockworkMiddleware.php
@@ -1,0 +1,92 @@
+<?php namespace Clockwork\Support\Slim\Old;
+
+use Clockwork\Clockwork;
+use Clockwork\DataSource\PhpDataSource;
+use Clockwork\DataSource\SlimDataSource;
+use Clockwork\Helpers\ServerTiming;
+use Clockwork\Storage\FileStorage;
+
+use Slim\Middleware;
+
+// Slim 2 middleware
+class ClockworkMiddleware extends Middleware
+{
+	private $storagePathOrClockwork;
+
+	public function __construct($storagePathOrClockwork)
+	{
+		$this->storagePathOrClockwork = $storagePathOrClockwork;
+	}
+
+	public function call()
+	{
+		$this->app->container->singleton('clockwork', function () {
+			if ($this->storagePathOrClockwork instanceof Clockwork) {
+				return $this->storagePathOrClockwork;
+			}
+
+			$clockwork = new Clockwork();
+
+			$clockwork->addDataSource(new PhpDataSource())
+				->addDataSource(new SlimDataSource($this->app))
+				->setStorage(new FileStorage($this->storagePathOrClockwork));
+
+			return $clockwork;
+		});
+
+		$originalLogWriter = $this->app->getLog()->getWriter();
+		$clockworkLogWriter = new ClockworkLogWriter($this->app->clockwork, $originalLogWriter);
+
+		$this->app->getLog()->setWriter($clockworkLogWriter);
+
+		$clockworkDataUri = '#/__clockwork(?:/(?<id>[0-9-]+))?(?:/(?<direction>(?:previous|next)))?(?:/(?<count>\d+))?#';
+		if ($this->app->config('debug') && preg_match($clockworkDataUri, $this->app->request()->getPathInfo(), $matches)) {
+			$matches = array_merge([ 'direction' => null, 'count' => null ], $matches);
+			return $this->retrieveRequest($matches['id'], $matches['direction'], $matches['count']);
+		}
+
+		try {
+			$this->next->call();
+			$this->logRequest();
+		} catch (Exception $e) {
+			$this->logRequest();
+			throw $e;
+		}
+	}
+
+	public function retrieveRequest($id = null, $direction = null, $count = null)
+	{
+		$storage = $this->app->clockwork->getStorage();
+
+		if ($direction == 'previous') {
+			$data = $storage->previous($id, $count);
+		} elseif ($direction == 'next') {
+			$data = $storage->next($id, $count);
+		} elseif ($id == 'latest') {
+			$data = $storage->latest();
+		} else {
+			$data = $storage->find($id);
+		}
+
+		echo json_encode($data, \JSON_PARTIAL_OUTPUT_ON_ERROR);
+	}
+
+	protected function logRequest()
+	{
+		$this->app->clockwork->resolveRequest();
+		$this->app->clockwork->storeRequest();
+
+		if ($this->app->config('debug')) {
+			$this->app->response()->header('X-Clockwork-Id', $this->app->clockwork->getRequest()->id);
+			$this->app->response()->header('X-Clockwork-Version', Clockwork::VERSION);
+
+			$env = $this->app->environment();
+			if ($env['SCRIPT_NAME']) {
+				$this->app->response()->header('X-Clockwork-Path', $env['SCRIPT_NAME'] . '/__clockwork/');
+			}
+
+			$request = $this->app->clockwork->getRequest();
+			$this->app->response()->header('Server-Timing', ServerTiming::fromRequest($request)->value());
+		}
+	}
+}


### PR DESCRIPTION
- added Slim 4 middleware
- moved old Slim middlewares
    - use `Clockwork\Support\Slim\ClockworkMiddleware` for Slim 4 support
    - use `Clockwork\Support\Slim\Legacy\ClockworkMiddleware` for Slim 3 support
    - use `Clockwork\Support\Slim\Old\ClockworkMiddleware` for Slim 2 support
- the Slim 4 middleware requires passing the app instance as the first argument

```php
$app = AppFactory::create();

$app->add(new Clockwork\Support\Slim\ClockworkMiddleware($app, __DIR__ . '/storage/clockwork'));

$app->run();
```