### PR TITLE
Request scoped global log

### DIFF
--- a/Clockwork/Clockwork.php
+++ b/Clockwork/Clockwork.php
@@ -43,11 +43,6 @@ class Clockwork implements LoggerInterface
 	// Authenticator implementation, authenticates requests for clockwork metadata
 	protected $authenticator;
 
-	/**
-	 * Request\Log instance, data structure which stores data for the log view
-	 */
-	protected $log;
-
 	// Callback to filter whether the request should be collected
 	protected $shouldCollect;
 
@@ -60,7 +55,6 @@ class Clockwork implements LoggerInterface
 	public function __construct()
 	{
 		$this->request = new Request;
-		$this->log = new Log;
 		$this->authenticator = new NullAuthenticator;
 
 		$this->shouldCollect = new ShouldCollect;
@@ -112,15 +106,7 @@ class Clockwork implements LoggerInterface
 			$dataSource->resolve($this->request);
 		}
 
-		// merge global log with data collected from data sources
-		$this->request->log = array_merge($this->request->log, $this->log->toArray());
-
-		// sort log data by time
-		uasort($this->request->log, function($a, $b) {
-			if ($a['time'] == $b['time']) return 0;
-			return $a['time'] < $b['time'] ? -1 : 1;
-		});
-
+		$this->request->log()->sort();
 		$this->request->timeline()->finalize($this->request->time);
 
 		return $this;
@@ -196,14 +182,12 @@ class Clockwork implements LoggerInterface
 		return $this->storage->store($this->request);
 	}
 
-	// Reset the log, timeline and all data sources to an empty state, clearing any collected data
+	// Reset all data sources to an empty state, clearing any collected data
 	public function reset()
 	{
 		foreach ($this->dataSources as $dataSource) {
 			$dataSource->reset();
 		}
-
-		$this->log = new Log;
 
 		return $this;
 	}
@@ -263,70 +247,52 @@ class Clockwork implements LoggerInterface
 	}
 
 	/**
-	 * Return the log instance
-	 */
-	public function getLog()
-	{
-		return $this->log;
-	}
-
-	/**
-	 * Set a custom log instance
-	 */
-	public function setLog(Log $log)
-	{
-		$this->log = $log;
-
-		return $this;
-	}
-
-	/**
 	 * Shortcut methods for the current log instance
 	 */
 
 	public function log($level = LogLevel::INFO, $message, array $context = [])
 	{
-		return $this->getLog()->log($level, $message, $context);
+		return $this->request->log()->log($level, $message, $context);
 	}
 
 	public function emergency($message, array $context = [])
 	{
-		return $this->getLog()->log(LogLevel::EMERGENCY, $message, $context);
+		return $this->request->log()->log(LogLevel::EMERGENCY, $message, $context);
 	}
 
 	public function alert($message, array $context = [])
 	{
-		return $this->getLog()->log(LogLevel::ALERT, $message, $context);
+		return $this->request->log()->log(LogLevel::ALERT, $message, $context);
 	}
 
 	public function critical($message, array $context = [])
 	{
-		return $this->getLog()->log(LogLevel::CRITICAL, $message, $context);
+		return $this->request->log()->log(LogLevel::CRITICAL, $message, $context);
 	}
 
 	public function error($message, array $context = [])
 	{
-		return $this->getLog()->log(LogLevel::ERROR, $message, $context);
+		return $this->request->log()->log(LogLevel::ERROR, $message, $context);
 	}
 
 	public function warning($message, array $context = [])
 	{
-		return $this->getLog()->log(LogLevel::WARNING, $message, $context);
+		return $this->request->log()->log(LogLevel::WARNING, $message, $context);
 	}
 
 	public function notice($message, array $context = [])
 	{
-		return $this->getLog()->log(LogLevel::NOTICE, $message, $context);
+		return $this->request->log()->log(LogLevel::NOTICE, $message, $context);
 	}
 
 	public function info($message, array $context = [])
 	{
-		return $this->getLog()->log(LogLevel::INFO, $message, $context);
+		return $this->request->log()->log(LogLevel::INFO, $message, $context);
 	}
 
 	public function debug($message, array $context = [])
 	{
-		return $this->getLog()->log(LogLevel::DEBUG, $message, $context);
+		return $this->request->log()->log(LogLevel::DEBUG, $message, $context);
 	}
 
 	// Shortcut methods for the current timeline instance

--- a/Clockwork/DataSource/Concerns/EloquentDetectDuplicateQueries.php
+++ b/Clockwork/DataSource/Concerns/EloquentDetectDuplicateQueries.php
@@ -27,7 +27,7 @@ trait EloquentDetectDuplicateQueries
 			);
 		}
 
-		$request->log = array_merge($request->log, $log->toArray());
+		$request->log()->merge($log);
 	}
 
 	protected function detectDuplicateQuery(StackTrace $trace)

--- a/Clockwork/DataSource/LaravelDataSource.php
+++ b/Clockwork/DataSource/LaravelDataSource.php
@@ -49,6 +49,7 @@ class LaravelDataSource extends DataSource
 		$this->collectLog = $collectLog;
 		$this->collectRoutes = $collectRoutes;
 
+		$this->log = new Log;
 		$this->timeline = new Timeline();
 	}
 
@@ -69,6 +70,7 @@ class LaravelDataSource extends DataSource
 
 		$this->resolveAuthenticatedUser($request);
 
+		$request->log()->merge($this->log);
 		$request->timeline()->merge($this->timeline);
 
 		return $request;
@@ -79,13 +81,6 @@ class LaravelDataSource extends DataSource
 	{
 		$this->timeline = new Timeline;
 		$this->views    = new Timeline;
-	}
-
-	// Set a log instance
-	public function setLog(Log $log)
-	{
-		$this->log = $log;
-		return $this;
 	}
 
 	/**

--- a/Clockwork/DataSource/LaravelDataSource.php
+++ b/Clockwork/DataSource/LaravelDataSource.php
@@ -79,6 +79,7 @@ class LaravelDataSource extends DataSource
 	// Reset the data source to an empty state, clearing any collected data
 	public function reset()
 	{
+		$this->log      = new Log;
 		$this->timeline = new Timeline;
 		$this->views    = new Timeline;
 	}

--- a/Clockwork/DataSource/LaravelDataSource.php
+++ b/Clockwork/DataSource/LaravelDataSource.php
@@ -4,13 +4,12 @@ use Clockwork\DataSource\DataSource;
 use Clockwork\Helpers\Serializer;
 use Clockwork\Request\Log;
 use Clockwork\Request\Request;
-use Clockwork\Request\Timeline\Timeline;
 
 use Illuminate\Contracts\Foundation\Application;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * Data source for Laravel framework, provides application log, timeline, request and response information
+ * Data source for Laravel framework, provides application log, request and response information
  */
 class LaravelDataSource extends DataSource
 {
@@ -29,11 +28,6 @@ class LaravelDataSource extends DataSource
 	 */
 	protected $log;
 
-	/**
-	 * Timeline data structure
-	 */
-	protected $timeline;
-
 	// Whether we should collect log messages
 	protected $collectLog = true;
 
@@ -50,11 +44,10 @@ class LaravelDataSource extends DataSource
 		$this->collectRoutes = $collectRoutes;
 
 		$this->log = new Log;
-		$this->timeline = new Timeline();
 	}
 
 	/**
-	 * Adds request method, uri, controller, headers, response status, timeline data and log entries to the request
+	 * Adds request method, uri, controller, headers, response status and log entries to the request
 	 */
 	public function resolve(Request $request)
 	{
@@ -71,7 +64,6 @@ class LaravelDataSource extends DataSource
 		$this->resolveAuthenticatedUser($request);
 
 		$request->log()->merge($this->log);
-		$request->timeline()->merge($this->timeline);
 
 		return $request;
 	}
@@ -79,9 +71,7 @@ class LaravelDataSource extends DataSource
 	// Reset the data source to an empty state, clearing any collected data
 	public function reset()
 	{
-		$this->log      = new Log;
-		$this->timeline = new Timeline;
-		$this->views    = new Timeline;
+		$this->log = new Log;
 	}
 
 	/**
@@ -94,17 +84,10 @@ class LaravelDataSource extends DataSource
 	}
 
 	/**
-	 * Hook up callbacks for various Laravel events, providing information for timeline and log entries
+	 * Hook up callbacks for various Laravel events, providing information for log entries
 	 */
 	public function listenToEvents()
 	{
-		$this->app['events']->listen('clockwork.controller.start', function () {
-			$this->timeline->event('Controller')->begin();
-		});
-		$this->app['events']->listen('clockwork.controller.end', function () {
-			$this->timeline->event('Controller')->end();
-		});
-
 		if ($this->collectLog) {
 			if (class_exists(\Illuminate\Log\Events\MessageLogged::class)) {
 				// Laravel 5.4

--- a/Clockwork/DataSource/LumenDataSource.php
+++ b/Clockwork/DataSource/LumenDataSource.php
@@ -49,6 +49,7 @@ class LumenDataSource extends DataSource
 		$this->collectLog = $collectLog;
 		$this->collectRoutes = $collectRoutes;
 
+		$this->log = new Log;
 		$this->timeline = new Timeline();
 	}
 
@@ -67,6 +68,7 @@ class LumenDataSource extends DataSource
 
 		$this->resolveAuthenticatedUser($request);
 
+		$request->log()->merge($this->log);
 		$request->timeline()->merge($this->timeline);
 
 		return $request;
@@ -76,13 +78,6 @@ class LumenDataSource extends DataSource
 	public function reset()
 	{
 		$this->timeline = new Timeline;
-	}
-
-	// Set a log instance
-	public function setLog(Log $log)
-	{
-		$this->log = $log;
-		return $this;
 	}
 
 	/**

--- a/Clockwork/DataSource/LumenDataSource.php
+++ b/Clockwork/DataSource/LumenDataSource.php
@@ -77,6 +77,7 @@ class LumenDataSource extends DataSource
 	// Reset the data source to an empty state, clearing any collected data
 	public function reset()
 	{
+		$this->log      = new Log;
 		$this->timeline = new Timeline;
 	}
 

--- a/Clockwork/DataSource/LumenDataSource.php
+++ b/Clockwork/DataSource/LumenDataSource.php
@@ -4,13 +4,12 @@ use Clockwork\DataSource\DataSource;
 use Clockwork\Helpers\Serializer;
 use Clockwork\Request\Log;
 use Clockwork\Request\Request;
-use Clockwork\Request\Timeline\Timeline;
 
 use Laravel\Lumen\Application;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * Data source for Lumen framework, provides application log, timeline, request and response information
+ * Data source for Lumen framework, provides application log, request and response information
  */
 class LumenDataSource extends DataSource
 {
@@ -29,11 +28,6 @@ class LumenDataSource extends DataSource
 	 */
 	protected $log;
 
-	/**
-	 * Timeline data structure
-	 */
-	protected $timeline;
-
 	// Whether we should collect log messages
 	protected $collectLog = true;
 
@@ -50,11 +44,10 @@ class LumenDataSource extends DataSource
 		$this->collectRoutes = $collectRoutes;
 
 		$this->log = new Log;
-		$this->timeline = new Timeline();
 	}
 
 	/**
-	 * Adds request method, uri, controller, headers, response status, timeline data and log entries to the request
+	 * Adds request method, uri, controller, headers, response status and log entries to the request
 	 */
 	public function resolve(Request $request)
 	{
@@ -69,7 +62,6 @@ class LumenDataSource extends DataSource
 		$this->resolveAuthenticatedUser($request);
 
 		$request->log()->merge($this->log);
-		$request->timeline()->merge($this->timeline);
 
 		return $request;
 	}
@@ -77,8 +69,7 @@ class LumenDataSource extends DataSource
 	// Reset the data source to an empty state, clearing any collected data
 	public function reset()
 	{
-		$this->log      = new Log;
-		$this->timeline = new Timeline;
+		$this->log = new Log;
 	}
 
 	/**
@@ -91,17 +82,10 @@ class LumenDataSource extends DataSource
 	}
 
 	/**
-	 * Hook up callbacks for various Laravel events, providing information for timeline and log entries
+	 * Hook up callbacks for various Laravel events, providing information for log entries
 	 */
 	public function listenToEvents()
 	{
-		$this->app['events']->listen('clockwork.controller.start', function () {
-			$this->timeline->event('Controller')->begin();
-		});
-		$this->app['events']->listen('clockwork.controller.end', function () {
-			$this->timeline->event('Controller')->end();
-		});
-
 		if ($this->collectLog) {
 			$this->app['events']->listen('illuminate.log', function ($level, $message, $context) {
 				$this->log->log($level, $message, $context);

--- a/Clockwork/DataSource/MonologDataSource.php
+++ b/Clockwork/DataSource/MonologDataSource.php
@@ -32,7 +32,7 @@ class MonologDataSource extends DataSource
 	 */
 	public function resolve(Request $request)
 	{
-		$request->log = array_merge($request->log, $this->log->toArray());
+		$request->log()->merge($this->log);
 
 		return $request;
 	}

--- a/Clockwork/Request/Log.php
+++ b/Clockwork/Request/Log.php
@@ -17,6 +17,12 @@ class Log extends AbstractLogger
 	 */
 	public $data = [];
 
+	// Create a new timeline, optionally with existing events
+	public function __construct($data = [])
+	{
+		$this->data = $data;
+	}
+
 	/**
 	 * Add a new timestamped message, with a level and context, context can be used to override serializer defaults
 	 * $context['trace'] = true can be used to force collecting a stack trace
@@ -33,6 +39,20 @@ class Log extends AbstractLogger
 			'time'      => microtime(true),
 			'trace'     => (new Serializer(! empty($context['trace']) ? [ 'traces' => true ] : []))->trace($trace)
 		];
+	}
+
+	// Merge another log instance into the current log
+	public function merge(Log $log)
+	{
+		$this->data = array_merge($this->data, $log->data);
+
+		return $this;
+	}
+
+	// Sort the log messages by start time
+	public function sort()
+	{
+		uasort($this->data, function ($a, $b) { return $a['time'] * 1000 - $b['time'] * 1000; });
 	}
 
 	/**

--- a/Clockwork/Request/Request.php
+++ b/Clockwork/Request/Request.php
@@ -266,6 +266,9 @@ class Request
 	// Token to update this request data
 	public $updateToken;
 
+	// Log instance for the current request
+	protected $currentLog;
+
 	// Timeline instance for the current request
 	protected $currentTimeline;
 
@@ -283,6 +286,7 @@ class Request
 			$this->$key = $val;
 		}
 
+		$this->currentLog = new Log($this->log);
 		$this->currentTimeline = new Timeline\Timeline($this->timelineData);
 	}
 
@@ -353,7 +357,7 @@ class Request
 			'redisCommands'            => $this->redisCommands,
 			'queueJobs'                => $this->queueJobs,
 			'timelineData'             => $this->timeline()->toArray(),
-			'log'                      => array_values($this->log),
+			'log'                      => $this->log()->toArray(),
 			'events'                   => $this->events,
 			'routes'                   => $this->routes,
 			'notifications'            => $this->notifications,
@@ -411,6 +415,12 @@ class Request
 		return array_filter($this->toArray(), function ($value, $key) use ($keys) {
 			return in_array($key, $keys);
 		}, ARRAY_FILTER_USE_BOTH);
+	}
+
+	// Return log instance for the current request
+	public function log()
+	{
+		return $this->currentLog;
 	}
 
 	// Return timeline instance for the current request

--- a/Clockwork/Support/Laravel/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Laravel/ClockworkServiceProvider.php
@@ -116,17 +116,12 @@ class ClockworkServiceProvider extends ServiceProvider
 		$this->app->singleton('clockwork', function ($app) {
 			return (new Clockwork)
 				->setAuthenticator($app['clockwork.authenticator'])
-				->setLog($app['clockwork.log'])
 				->setRequest($app['clockwork.request'])
 				->setStorage($app['clockwork.storage']);
 		});
 
 		$this->app->singleton('clockwork.authenticator', function ($app) {
 			return $app['clockwork.support']->getAuthenticator();
-		});
-
-		$this->app->singleton('clockwork.log', function ($app) {
-			return new Log;
 		});
 
 		$this->app->singleton('clockwork.request', function ($app) {
@@ -218,8 +213,7 @@ class ClockworkServiceProvider extends ServiceProvider
 				$app,
 				$app['clockwork.support']->isFeatureEnabled('log'),
 				$app['clockwork.support']->isFeatureEnabled('routes')
-			))
-				->setLog($app['clockwork.log']);
+			));
 		});
 
 		$this->app->singleton('clockwork.notifications', function ($app) {
@@ -274,7 +268,6 @@ class ClockworkServiceProvider extends ServiceProvider
 		$this->app->alias('clockwork', Clockwork::class);
 
 		$this->app->alias('clockwork.authenticator', AuthenticatorInterface::class);
-		$this->app->alias('clockwork.log', Log::class);
 		$this->app->alias('clockwork.storage', StorageInterface::class);
 		$this->app->alias('clockwork.support', ClockworkSupport::class);
 

--- a/Clockwork/Support/Lumen/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Lumen/ClockworkServiceProvider.php
@@ -26,7 +26,6 @@ class ClockworkServiceProvider extends LaravelServiceProvider
 
 			$clockwork = (new Clockwork)
 				->setAuthenticator($app['clockwork.authenticator'])
-				->setLog($app['clockwork.log'])
 				->setRequest($app['clockwork.request'])
 				->setStorage($app['clockwork.storage'])
 				->addDataSource(new PhpDataSource())
@@ -45,10 +44,6 @@ class ClockworkServiceProvider extends LaravelServiceProvider
 
 		$this->app->singleton('clockwork.authenticator', function ($app) {
 			return $app['clockwork.support']->getAuthenticator();
-		});
-
-		$this->app->singleton('clockwork.log', function ($app) {
-			return new Log;
 		});
 
 		$this->app->singleton('clockwork.request', function ($app) {
@@ -89,8 +84,7 @@ class ClockworkServiceProvider extends LaravelServiceProvider
 				$app['clockwork.support']->isFeatureEnabled('log'),
 				$app['clockwork.support']->isFeatureEnabled('views'),
 				$app['clockwork.support']->isFeatureEnabled('routes')
-			))
-				->setLog($app['clockwork.log']);
+			));
 		});
 	}
 

--- a/Clockwork/Support/Symfony/ProfileTransformer.php
+++ b/Clockwork/Support/Symfony/ProfileTransformer.php
@@ -1,6 +1,7 @@
 <?php namespace Clockwork\Support\Symfony;
 
 use Clockwork\Helpers\Serializer;
+use Clockwork\Request\Log;
 use Clockwork\Request\Request;
 use Clockwork\Request\Timeline\Timeline;
 
@@ -150,12 +151,12 @@ class ProfileTransformer
 
 		$data = $profile->getCollector('logger');
 
-		$request->log = $this->getLog($data);
+		$request->log()->merge($this->getLog($data));
 	}
 
 	protected function getLog($data)
 	{
-		return array_map(function ($log) {
+		$messages = array_map(function ($log) {
 			$context = isset($log['context']) ? $log['context'] : [];
 			$replacements = array_filter($context, function ($v) { return ! is_array($v) && ! is_object($v) && ! is_resource($v); });
 
@@ -170,6 +171,8 @@ class ProfileTransformer
 				'time'    => $log['timestamp']
 			];
 		}, $this->unwrap($data->getLogs()));
+
+		return new Log($messages);
 	}
 
 	// Request collector


### PR DESCRIPTION
- moved global log to the request instance
- removed legacy clockwork.controller event listeners

## Breaking

- if you need to access the global timeline instance it was moved to the request

```php
// old api
$log = clock()->getLog();

// new api
$log = clock()->getRequest()->log();
```

- request's log attribute should never be manually modified in custom data sources, the log instance should be used instead, eg.

```php
// old api
$request->log = array_merge($request->log, $localLog->toArray());

// new api
$request->log()->merge($localLog);
```

- the `clockwork.log` and `Clockwork\Request\Log::class` are no longer registered in Laravel container
- the `clockwork.controller.start` and `clockwork.controller.end` events are no longer used and can be removed
