### PR TITLE
Fix for deprecated required parameter after optional

### DIFF
--- a/Clockwork/Request/Log.php
+++ b/Clockwork/Request/Log.php
@@ -19,7 +19,7 @@ class Log extends AbstractLogger
 
 	// Log a new message, with a level and context, context can be used to override serializer defaults,
 	// $context['trace'] = true can be used to force collecting a stack trace
-	public function log($level = LogLevel::INFO, $message, array $context = [])
+	public function log($level = LogLevel::INFO, $message = null, array $context = [])
 	{
 		$trace = $this->hasTrace($context) ? $context['trace'] : StackTrace::get()->resolveViewName();
 


### PR DESCRIPTION
PHP 8 deprecates required parameter in a position that is after another optional parameter.

The error is `Deprecated: Required parameter $message follows optional parameter $level in vendor/itsgoingd/clockwork/Clockwork/Request/Log.php on line 22`.

I changed the signature to be the same as in `Clockwork::log` which is also there the same error is reported when using clockwork v4.

Thanks