### PR TITLE
Keep PHP 5.6 compactibility

### DIFF
--- a/Clockwork/Clockwork.php
+++ b/Clockwork/Clockwork.php
@@ -1,9 +1,14 @@
 <?php namespace Clockwork;
 
-use Clockwork\Authentication\{AuthenticatorInterface, NullAuthenticator};
+use Clockwork\Authentication\AuthenticatorInterface;
+use Clockwork\Authentication\NullAuthenticator;
 use Clockwork\DataSource\DataSourceInterface;
 use Clockwork\Helpers\Serializer;
-use Clockwork\Request\{Log, Request, RequestType, ShouldCollect, ShouldRecord};
+use Clockwork\Request\Log;
+use Clockwork\Request\Request;
+use Clockwork\Request\RequestType;
+use Clockwork\Request\ShouldCollect;
+use Clockwork\Request\ShouldRecord;
 use Clockwork\Storage\StorageInterface;
 
 // A central class implementing the core flow of the library

--- a/Clockwork/DataSource/DBALDataSource.php
+++ b/Clockwork/DataSource/DBALDataSource.php
@@ -3,7 +3,8 @@
 use Clockwork\Request\Request;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Logging\{LoggerChain, SQLLogger};
+use Doctrine\DBAL\Logging\LoggerChain;
+use Doctrine\DBAL\Logging\SQLLogger;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 

--- a/Clockwork/DataSource/EloquentDataSource.php
+++ b/Clockwork/DataSource/EloquentDataSource.php
@@ -1,8 +1,10 @@
 <?php namespace Clockwork\DataSource;
 
-use Clockwork\Helpers\{Serializer, StackTrace};
+use Clockwork\Helpers\Serializer;
+use Clockwork\Helpers\StackTrace;
 use Clockwork\Request\Request;
-use Clockwork\Support\Laravel\Eloquent\{ResolveModelScope, ResolveModelLegacyScope};
+use Clockwork\Support\Laravel\Eloquent\ResolveModelLegacyScope;
+use Clockwork\Support\Laravel\Eloquent\ResolveModelScope;
 
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;

--- a/Clockwork/DataSource/LaravelCacheDataSource.php
+++ b/Clockwork/DataSource/LaravelCacheDataSource.php
@@ -1,6 +1,7 @@
 <?php namespace Clockwork\DataSource;
 
-use Clockwork\Helpers\{Serializer, StackTrace};
+use Clockwork\Helpers\Serializer;
+use Clockwork\Helpers\StackTrace;
 use Clockwork\Request\Request;
 
 use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;

--- a/Clockwork/DataSource/LaravelDataSource.php
+++ b/Clockwork/DataSource/LaravelDataSource.php
@@ -2,7 +2,8 @@
 
 use Clockwork\DataSource\DataSource;
 use Clockwork\Helpers\Serializer;
-use Clockwork\Request\{Log, Request};
+use Clockwork\Request\Log;
+use Clockwork\Request\Request;
 
 use Illuminate\Contracts\Foundation\Application;
 use Symfony\Component\HttpFoundation\Response;

--- a/Clockwork/DataSource/LaravelEventsDataSource.php
+++ b/Clockwork/DataSource/LaravelEventsDataSource.php
@@ -1,6 +1,7 @@
 <?php namespace Clockwork\DataSource;
 
-use Clockwork\Helpers\{Serializer, StackTrace};
+use Clockwork\Helpers\Serializer;
+use Clockwork\Helpers\StackTrace;
 use Clockwork\Request\Request;
 
 use Illuminate\Contracts\Events\Dispatcher;

--- a/Clockwork/DataSource/LaravelNotificationsDataSource.php
+++ b/Clockwork/DataSource/LaravelNotificationsDataSource.php
@@ -1,12 +1,15 @@
 <?php namespace Clockwork\DataSource;
 
-use Clockwork\Helpers\{Serializer, StackTrace};
+use Clockwork\Helpers\Serializer;
+use Clockwork\Helpers\StackTrace;
 use Clockwork\Request\Request;
 
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Mail\Mailable;
-use Illuminate\Mail\Events\{MessageSending, MessageSent};
-use Illuminate\Notifications\Events\{NotificationSending, NotificationSent};
+use Illuminate\Mail\Events\MessageSending;
+use Illuminate\Mail\Events\MessageSent;
+use Illuminate\Notifications\Events\NotificationSending;
+use Illuminate\Notifications\Events\NotificationSent;
 
 // Data source for Laravel notifications and mail components, provides sent notifications and emails
 class LaravelNotificationsDataSource extends DataSource

--- a/Clockwork/DataSource/LaravelQueueDataSource.php
+++ b/Clockwork/DataSource/LaravelQueueDataSource.php
@@ -1,6 +1,7 @@
 <?php namespace Clockwork\DataSource;
 
-use Clockwork\Helpers\{Serializer, StackTrace};
+use Clockwork\Helpers\Serializer;
+use Clockwork\Helpers\StackTrace;
 use Clockwork\Request\Request;
 
 use Illuminate\Queue\Queue;

--- a/Clockwork/DataSource/LaravelRedisDataSource.php
+++ b/Clockwork/DataSource/LaravelRedisDataSource.php
@@ -1,6 +1,7 @@
 <?php namespace Clockwork\DataSource;
 
-use Clockwork\Helpers\{Serializer, StackTrace};
+use Clockwork\Helpers\Serializer;
+use Clockwork\Helpers\StackTrace;
 use Clockwork\Request\Request;
 
 use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;

--- a/Clockwork/DataSource/LumenDataSource.php
+++ b/Clockwork/DataSource/LumenDataSource.php
@@ -2,7 +2,8 @@
 
 use Clockwork\DataSource\DataSource;
 use Clockwork\Helpers\Serializer;
-use Clockwork\Request\{Log, Request};
+use Clockwork\Request\Log;
+use Clockwork\Request\Request;
 
 use Laravel\Lumen\Application;
 use Symfony\Component\HttpFoundation\Response;

--- a/Clockwork/DataSource/MonologDataSource.php
+++ b/Clockwork/DataSource/MonologDataSource.php
@@ -1,7 +1,8 @@
 <?php namespace Clockwork\DataSource;
 
 use Clockwork\DataSource\DataSource;
-use Clockwork\Request\{Log, Request};
+use Clockwork\Request\Log;
+use Clockwork\Request\Request;
 use Clockwork\Support\Monolog\Handler\ClockworkHandler;
 
 use Monolog\Logger as Monolog;

--- a/Clockwork/Request/Log.php
+++ b/Clockwork/Request/Log.php
@@ -1,6 +1,8 @@
 <?php namespace Clockwork\Request;
 
-use Clockwork\Helpers\{Serializer, StackTrace, StackFilter};
+use Clockwork\Helpers\Serializer;
+use Clockwork\Helpers\StackTrace;
+use Clockwork\Helpers\StackFilter;
 
 use Psr\Log\AbstractLogger;
 use Psr\Log\LogLevel;

--- a/Clockwork/Storage/Search.php
+++ b/Clockwork/Storage/Search.php
@@ -1,6 +1,7 @@
 <?php namespace Clockwork\Storage;
 
-use Clockwork\Request\{Request, RequestType};
+use Clockwork\Request\Request;
+use Clockwork\Request\RequestType;
 
 // Rules for searching requests
 class Search

--- a/Clockwork/Support/Laravel/ClockworkController.php
+++ b/Clockwork/Support/Laravel/ClockworkController.php
@@ -1,7 +1,8 @@
 <?php namespace Clockwork\Support\Laravel;
 
 use Illuminate\Contracts\Foundation\Application;
-use Illuminate\Http\{JsonResponse, RedirectResponse};
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Controller;
 use Laravel\Telescope\Telescope;
 

--- a/Clockwork/Support/Laravel/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Laravel/ClockworkServiceProvider.php
@@ -2,11 +2,18 @@
 
 use Clockwork\Clockwork;
 use Clockwork\Authentication\AuthenticatorInterface;
-use Clockwork\DataSource\{
-	EloquentDataSource, LaravelDataSource, LaravelCacheDataSource, LaravelEventsDataSource,
-	LaravelNotificationsDataSource, LaravelRedisDataSource, LaravelQueueDataSource, LaravelTwigDataSource,
-	LaravelViewsDataSource, SwiftDataSource, TwigDataSource, XdebugDataSource
-};
+use Clockwork\DataSource\EloquentDataSource;
+use Clockwork\DataSource\LaravelCacheDataSource;
+use Clockwork\DataSource\LaravelDataSource;
+use Clockwork\DataSource\LaravelEventsDataSource;
+use Clockwork\DataSource\LaravelNotificationsDataSource;
+use Clockwork\DataSource\LaravelQueueDataSource;
+use Clockwork\DataSource\LaravelRedisDataSource;
+use Clockwork\DataSource\LaravelTwigDataSource;
+use Clockwork\DataSource\LaravelViewsDataSource;
+use Clockwork\DataSource\SwiftDataSource;
+use Clockwork\DataSource\TwigDataSource;
+use Clockwork\DataSource\XdebugDataSource;
 use Clockwork\Helpers\StackFilter;
 use Clockwork\Request\Request;
 use Clockwork\Storage\StorageInterface;

--- a/Clockwork/Support/Laravel/ClockworkSupport.php
+++ b/Clockwork/Support/Laravel/ClockworkSupport.php
@@ -1,18 +1,27 @@
 <?php namespace Clockwork\Support\Laravel;
 
 use Clockwork\Clockwork;
-use Clockwork\Authentication\{NullAuthenticator, SimpleAuthenticator};
+use Clockwork\Authentication\NullAuthenticator;
+use Clockwork\Authentication\SimpleAuthenticator;
 use Clockwork\DataSource\PhpDataSource;
-use Clockwork\Helpers\{Serializer, ServerTiming, StackFilter, StackTrace};
-use Clockwork\Request\{IncomingRequest, Request};
-use Clockwork\Storage\{FileStorage, Search, SqlStorage};
+use Clockwork\Helpers\Serializer;
+use Clockwork\Helpers\ServerTiming;
+use Clockwork\Helpers\StackFilter;
+use Clockwork\Helpers\StackTrace;
+use Clockwork\Request\IncomingRequest;
+use Clockwork\Request\Request;
+use Clockwork\Storage\FileStorage;
+use Clockwork\Storage\Search;
+use Clockwork\Storage\SqlStorage;
 use Clockwork\Web\Web;
 
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
-use Illuminate\Http\{JsonResponse, Response};
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
 use Illuminate\Redis\RedisManager;
-use Symfony\Component\HttpFoundation\{BinaryFileResponse, Cookie};
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 // Support class for the Laravel integration

--- a/Clockwork/Support/Laravel/Tests/UsesClockwork.php
+++ b/Clockwork/Support/Laravel/Tests/UsesClockwork.php
@@ -1,6 +1,8 @@
 <?php namespace Clockwork\Support\Laravel\Tests;
 
-use Clockwork\Helpers\{Serializer, StackFilter, StackTrace};
+use Clockwork\Helpers\Serializer;
+use Clockwork\Helpers\StackFilter;
+use Clockwork\Helpers\StackTrace;
 
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Runner\BaseTestRunner;
@@ -64,7 +66,7 @@ trait UsesClockwork
 	}
 
 	// Overload the main PHPUnit assert method to collect executed asserts
-	public static function assertThat($value, Constraint $constraint, string $message = ''): void
+	public static function assertThat($value, Constraint $constraint, string $message = '')
 	{
 		$trace = StackTrace::get([ 'arguments' => true, 'limit' => 10 ]);
 

--- a/Clockwork/Support/Laravel/Tests/UsesClockwork.php
+++ b/Clockwork/Support/Laravel/Tests/UsesClockwork.php
@@ -66,7 +66,7 @@ trait UsesClockwork
 	}
 
 	// Overload the main PHPUnit assert method to collect executed asserts
-	public static function assertThat($value, Constraint $constraint, string $message = '')
+	public static function assertThat($value, Constraint $constraint, string $message = ''): void
 	{
 		$trace = StackTrace::get([ 'arguments' => true, 'limit' => 10 ]);
 

--- a/Clockwork/Support/Lumen/Controller.php
+++ b/Clockwork/Support/Lumen/Controller.php
@@ -3,7 +3,9 @@
 use Clockwork\Clockwork;
 use Clockwork\Support\Lumen\ClockworkSupport;
 
-use Illuminate\Http\{JsonResponse, RedirectResponse, Request};
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Laravel\Lumen\Routing\Controller as LumenController;
 use Laravel\Telescope\Telescope;
 

--- a/Clockwork/Support/Vanilla/Clockwork.php
+++ b/Clockwork/Support/Vanilla/Clockwork.php
@@ -1,10 +1,15 @@
 <?php namespace Clockwork\Support\Vanilla;
 
 use Clockwork\Clockwork as BaseClockwork;
-use Clockwork\DataSource\{PhpDataSource, PsrMessageDataSource};
-use Clockwork\Helpers\{Serializer, ServerTiming, StackFilter};
+use Clockwork\DataSource\PhpDataSource;
+use Clockwork\DataSource\PsrMessageDataSource;
+use Clockwork\Helpers\Serializer;
+use Clockwork\Helpers\ServerTiming;
+use Clockwork\Helpers\StackFilter;
 use Clockwork\Request\IncomingRequest;
-use Clockwork\Storage\{FileStorage, Search, SqlStorage};
+use Clockwork\Storage\FileStorage;
+use Clockwork\Storage\Search;
+use Clockwork\Storage\SqlStorage;
 
 use Psr\Http\Message\ServerRequestInterface as PsrRequest;
 use Psr\Http\Message\ResponseInterface as PsrResponse;


### PR DESCRIPTION
composer.json states that we can use PHP >= 5.6, however using group uses in the code causes fatal errors. I have split them to keep up PHP 5.6 compatibility.