### PR TITLE
Rename getTimeline() to fix Slim middleware fatals

### DIFF
--- a/Clockwork/Support/Slim/ClockworkMiddleware.php
+++ b/Clockwork/Support/Slim/ClockworkMiddleware.php
@@ -80,7 +80,7 @@ class ClockworkMiddleware
 
 	protected function logRequest(Request $request, $response)
 	{
-		$this->clockwork->getTimeline()->finalize($this->startTime);
+		$this->clockwork->timeline()->finalize($this->startTime);
 		$this->clockwork->addDataSource(new PsrMessageDataSource($request, $response));
 
 		$this->clockwork->resolveRequest();

--- a/Clockwork/Support/Slim/Legacy/ClockworkMiddleware.php
+++ b/Clockwork/Support/Slim/Legacy/ClockworkMiddleware.php
@@ -82,7 +82,7 @@ class ClockworkMiddleware
 
 	protected function logRequest(Request $request, Response $response)
 	{
-		$this->clockwork->getTimeline()->finalize($this->startTime);
+		$this->clockwork->timeline()->finalize($this->startTime);
 		$this->clockwork->addDataSource(new PsrMessageDataSource($request, $response));
 
 		$this->clockwork->resolveRequest();


### PR DESCRIPTION
Fixes #452.