### PR TITLE
Add possibility to collect cache keys only

### DIFF
--- a/Clockwork/DataSource/LaravelCacheDataSource.php
+++ b/Clockwork/DataSource/LaravelCacheDataSource.php
@@ -111,10 +111,10 @@ class LaravelCacheDataSource extends DataSource
 		];
 
 		if ($this->excludeResults) {
-            $query['value'] = '[excluded]';
-        } else if (isset($query['value'])) {
-            $query['value'] = (new Serializer)->normalize($query['value']);
-        }
+			$query['value'] = '[excluded]';
+		} else if (isset($query['value'])) {
+			$query['value'] = (new Serializer)->normalize($query['value']);
+		}
 
 		$this->incrementQueryCount($query);
 

--- a/Clockwork/DataSource/LaravelCacheDataSource.php
+++ b/Clockwork/DataSource/LaravelCacheDataSource.php
@@ -23,12 +23,16 @@ class LaravelCacheDataSource extends DataSource
 	// Whether we are collecting cache queries or stats only
 	protected $collectQueries = true;
 
+	// Whether we are excluding cache results
+	protected $excludeResults = true;
+
 	// Create a new data source instance, takes an event dispatcher and additional options as argument
-	public function __construct(EventDispatcher $eventDispatcher, $collectQueries = true)
+	public function __construct(EventDispatcher $eventDispatcher, $collectQueries = true, $excludeResults = true)
 	{
 		$this->eventDispatcher = $eventDispatcher;
 
 		$this->collectQueries = $collectQueries;
+		$this->excludeResults = $excludeResults;
 	}
 
 	// Adds cache queries and stats to the request
@@ -100,11 +104,17 @@ class LaravelCacheDataSource extends DataSource
 		$query = [
 			'type'       => $query['type'],
 			'key'        => $query['key'],
-			'value'      => isset($query['value']) ? (new Serializer)->normalize($query['value']) : null,
+			'value'      => null,
 			'time'       => microtime(true),
 			'connection' => null,
 			'trace'      => (new Serializer)->trace($trace)
 		];
+
+		if ($this->excludeResults) {
+            $query['value'] = '[excluded]';
+        } else if (isset($query['value'])) {
+            $query['value'] = (new Serializer)->normalize($query['value']);
+        }
 
 		$this->incrementQueryCount($query);
 

--- a/Clockwork/DataSource/LaravelCacheDataSource.php
+++ b/Clockwork/DataSource/LaravelCacheDataSource.php
@@ -101,7 +101,7 @@ class LaravelCacheDataSource extends DataSource
 	{
 		$trace = StackTrace::get()->resolveViewName();
 
-		$query = [
+		$record = [
 			'type'       => $query['type'],
 			'key'        => $query['key'],
 			'value'      => null,
@@ -111,15 +111,15 @@ class LaravelCacheDataSource extends DataSource
 		];
 
 		if ($this->excludeResults) {
-			$query['value'] = '[excluded]';
+            $record['value'] = '[excluded]';
 		} else if (isset($query['value'])) {
-			$query['value'] = (new Serializer)->normalize($query['value']);
+            $record['value'] = (new Serializer)->normalize($query['value']);
 		}
 
-		$this->incrementQueryCount($query);
+		$this->incrementQueryCount($record);
 
-		if ($this->collectQueries && $this->passesFilters([ $query ])) {
-			$this->queries[] = $query;
+		if ($this->collectQueries && $this->passesFilters([ $record ])) {
+			$this->queries[] = $record;
 		}
 	}
 

--- a/Clockwork/Support/Laravel/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Laravel/ClockworkServiceProvider.php
@@ -108,7 +108,8 @@ class ClockworkServiceProvider extends ServiceProvider
 		$this->app->singleton('clockwork.cache', function ($app) {
 			return (new LaravelCacheDataSource(
 				$app['events'],
-				$app['clockwork.support']->getConfig('features.cache.collect_queries')
+				$app['clockwork.support']->getConfig('features.cache.collect_queries'),
+				$app['clockwork.support']->getConfig('features.cache.exclude_results')
 			));
 		});
 

--- a/Clockwork/Support/Laravel/config/clockwork.php
+++ b/Clockwork/Support/Laravel/config/clockwork.php
@@ -31,10 +31,10 @@ return [
 			'enabled' => env('CLOCKWORK_CACHE_ENABLED', true),
 
             // Collect cache queries
-            'collect_queries' => env('CLOCKWORK_CACHE_QUERIES', true),
+			'collect_queries' => env('CLOCKWORK_CACHE_QUERIES', true),
 
-            // Exclude results from cache queries (can increase performance with a high number of queries)
-            'exclude_results' => env('CLOCKWORK_CACHE_EXCLUDE_RESULTS', true)
+			// Exclude results from cache queries (can increase performance with a high number of queries)
+			'exclude_results' => env('CLOCKWORK_CACHE_EXCLUDE_RESULTS', true)
 		],
 
 		// Database usage stats and queries

--- a/Clockwork/Support/Laravel/config/clockwork.php
+++ b/Clockwork/Support/Laravel/config/clockwork.php
@@ -30,8 +30,11 @@ return [
 		'cache' => [
 			'enabled' => env('CLOCKWORK_CACHE_ENABLED', true),
 
-			// Collect cache queries including results (high performance impact with a high number of queries)
-			'collect_queries' => env('CLOCKWORK_CACHE_QUERIES', false)
+            // Collect cache queries
+            'collect_queries' => env('CLOCKWORK_CACHE_QUERIES', true),
+
+            // Exclude results from cache queries (can increase performance with a high number of queries)
+            'exclude_results' => env('CLOCKWORK_CACHE_EXCLUDE_RESULTS', true)
 		],
 
 		// Database usage stats and queries


### PR DESCRIPTION
Adds the possibility to collect cache keys only. Its dramatically increases performance, when `collect_queries` option is enabled.

Related to https://github.com/itsgoingd/clockwork/issues/471