### PR TITLE
Fixing notifications using replyTo

### DIFF
--- a/Clockwork/DataSource/LaravelNotificationsDataSource.php
+++ b/Clockwork/DataSource/LaravelNotificationsDataSource.php
@@ -223,6 +223,10 @@ class LaravelNotificationsDataSource extends DataSource
 
 		return array_map(function ($address) {
 			if (! is_array($address)) return $address;
+			
+			if (! array_key_exists('name', $address)) {
+                		return $address[0];
+            		}
 
 			return $address['name'] ? "{$address['name']} <{$address['address']}>" : $address['address'];
 		}, $address);


### PR DESCRIPTION
This pr aims to fix an exception that gets thrown when notifications are sent using `replyTo` like this:

```php
->replyTo($email)
```

![Bildschirmfoto 2021-04-01 um 10 31 27](https://user-images.githubusercontent.com/29352871/113267925-25848d80-92d7-11eb-8dc1-b78f33bc19ed.png)
