### PR TITLE
fix quoteBinding when elasticsearch connection is used for eloquent Models

### DIFF
--- a/Clockwork/DataSource/EloquentDataSource.php
+++ b/Clockwork/DataSource/EloquentDataSource.php
@@ -257,7 +257,7 @@ class EloquentDataSource extends DataSource
 	protected function quoteBinding($binding, $connection)
 	{
 		$connection = $this->databaseManager->connection($connection);
-		if (get_class($connection) === 'DesignMyNight\Elasticsearch\Connection') {
+		if (!method_exists($connection, 'getPdo') || $connection->getPdo() === null) {
 			return;
 		}
 		if ($connection->getPdo()->getAttribute(\PDO::ATTR_DRIVER_NAME) === 'odbc') {

--- a/Clockwork/DataSource/EloquentDataSource.php
+++ b/Clockwork/DataSource/EloquentDataSource.php
@@ -257,7 +257,9 @@ class EloquentDataSource extends DataSource
 	protected function quoteBinding($binding, $connection)
 	{
 		$connection = $this->databaseManager->connection($connection);
-
+		if (get_class($connection) === 'DesignMyNight\Elasticsearch\Connection') {
+			return;
+		}
 		if ($connection->getPdo()->getAttribute(\PDO::ATTR_DRIVER_NAME) === 'odbc') {
 			// PDO_ODBC driver doesn't support the quote method, apply simple MSSQL style quoting instead
 			return "'" . str_replace("'", "''", $binding) . "'";


### PR DESCRIPTION
Not all eloquent datasources have a PDO. for example elasticsearch