### PR TITLE
Laravel - collect routes only from specified namespaces

### DIFF
--- a/Clockwork/Support/Laravel/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Laravel/ClockworkServiceProvider.php
@@ -155,7 +155,8 @@ class ClockworkServiceProvider extends ServiceProvider
 			return (new LaravelDataSource(
 				$app,
 				$app['clockwork.support']->isFeatureEnabled('log'),
-				$app['clockwork.support']->isFeatureEnabled('routes')
+				$app['clockwork.support']->isFeatureEnabled('routes'),
+				$app['clockwork.support']->getConfig('features.routes.only_namespaces', [])
 			));
 		});
 

--- a/Clockwork/Support/Laravel/config/clockwork.php
+++ b/Clockwork/Support/Laravel/config/clockwork.php
@@ -99,7 +99,10 @@ return [
 
 		// Routes list
 		'routes' => [
-			'enabled' => env('CLOCKWORK_ROUTES_ENABLED', false)
+			'enabled' => env('CLOCKWORK_ROUTES_ENABLED', false),
+
+			// Collect only routes from particular namespaces (only application routes by default)
+			'only_namespaces' => [ 'App' ]
 		],
 
 		// Rendered views


### PR DESCRIPTION
- added an option to collect routes only from particular namespaces in Laravel
- by default collect routes only from the App namespace