### PR TITLE
Make sure slack's `to` data is in an array

### DIFF
--- a/Clockwork/DataSource/LaravelNotificationsDataSource.php
+++ b/Clockwork/DataSource/LaravelNotificationsDataSource.php
@@ -136,7 +136,7 @@ class LaravelNotificationsDataSource extends DataSource
 	{
 		if (! $this->lastNotification) return false;
 
-		if (implode($this->lastNotification->to) != implode($notification->to)) return false;
+		if ($this->lastNotification->to !== $notification->to) return false;
 
 		$this->lastNotification->subject = $notification->subject;
 		$this->lastNotification->from    = $notification->from;


### PR DESCRIPTION
[`$channel`](https://github.com/laravel/slack-notification-channel/blob/ff32393db15bfd779c1dcddda37f559eafb83c04/src/Messages/SlackMessage.php#L37-L42) is string so it needs to be put in an array otherwise it fails on PHP 8 as [`implode`](https://github.com/itsgoingd/clockwork/blob/c1caac71fec77ad623e26a02408f05ca7ce36153/Clockwork/DataSource/LaravelNotificationsDataSource.php#L139) throws errors on invalid parameter (`implode('test')`).

Not tested for other thing although it's correct type for mail at least.