### PR TITLE
Add config except telescope toolbar

### DIFF
--- a/Clockwork/Support/Laravel/config/clockwork.php
+++ b/Clockwork/Support/Laravel/config/clockwork.php
@@ -175,6 +175,7 @@ return [
 		'except' => [
 			'/horizon/.*', // Laravel Horizon requests
 			'/telescope/.*', // Laravel Telescope requests
+			'/_tt/.*', // Laravel Telescope toolbar
 			'/_debugbar/.*', // Laravel DebugBar requests
 		],
 


### PR DESCRIPTION
We using this https://github.com/fruitcake/laravel-telescope-toolbar

with default config 
https://github.com/fruitcake/laravel-telescope-toolbar/blob/929379119881e959e018528d0d820ac5f2c21b76/config/telescope-toolbar.php#L37

Thank you