### PR TITLE
Fix ShouldCollect/ShouldRecord callback filters

### DIFF
--- a/Clockwork/Request/ShouldCollect.php
+++ b/Clockwork/Request/ShouldCollect.php
@@ -106,7 +106,7 @@ class ShouldCollect
 	{
 		if (! $this->callback) return true;
 
-		return $this->callback($request);
+		return ($this->callback)($request);
 	}
 
 	public function __call($method, $parameters)

--- a/Clockwork/Request/ShouldCollect.php
+++ b/Clockwork/Request/ShouldCollect.php
@@ -106,7 +106,7 @@ class ShouldCollect
 	{
 		if (! $this->callback) return true;
 
-		return ($this->callback)($request);
+		return call_user_func($this->callback, $request);
 	}
 
 	public function __call($method, $parameters)

--- a/Clockwork/Request/ShouldRecord.php
+++ b/Clockwork/Request/ShouldRecord.php
@@ -43,7 +43,7 @@ class ShouldRecord
 	{
 		if (! $this->callback) return true;
 
-		return $this->callback($request);
+		return ($this->callback)($request);
 	}
 
 	// Fluent API

--- a/Clockwork/Request/ShouldRecord.php
+++ b/Clockwork/Request/ShouldRecord.php
@@ -43,7 +43,7 @@ class ShouldRecord
 	{
 		if (! $this->callback) return true;
 
-		return ($this->callback)($request);
+		return call_user_func($this->callback, $request);
 	}
 
 	// Fluent API


### PR DESCRIPTION
Without parens, PHP sees `$this->callback($request)` as a call to the method `callback`. Since it doesn't exist, `__call` is used which is actually setting a new value for the `$callback` param instead of invoking it.