### PR TITLE
Nullable search

### DIFF
--- a/Clockwork/Request/ShouldCollect.php
+++ b/Clockwork/Request/ShouldCollect.php
@@ -106,7 +106,7 @@ class ShouldCollect
 	{
 		if (! $this->callback) return true;
 
-		return $this->callback($request);
+		return ($this->callback)($request);
 	}
 
 	public function __call($method, $parameters)

--- a/Clockwork/Request/ShouldCollect.php
+++ b/Clockwork/Request/ShouldCollect.php
@@ -106,7 +106,7 @@ class ShouldCollect
 	{
 		if (! $this->callback) return true;
 
-		return ($this->callback)($request);
+		return call_user_func($this->callback, $request);
 	}
 
 	public function __call($method, $parameters)

--- a/Clockwork/Request/ShouldRecord.php
+++ b/Clockwork/Request/ShouldRecord.php
@@ -43,7 +43,7 @@ class ShouldRecord
 	{
 		if (! $this->callback) return true;
 
-		return $this->callback($request);
+		return ($this->callback)($request);
 	}
 
 	// Fluent API

--- a/Clockwork/Request/ShouldRecord.php
+++ b/Clockwork/Request/ShouldRecord.php
@@ -43,7 +43,7 @@ class ShouldRecord
 	{
 		if (! $this->callback) return true;
 
-		return ($this->callback)($request);
+		return call_user_func($this->callback, $request);
 	}
 
 	// Fluent API

--- a/Clockwork/Storage/SqlSearch.php
+++ b/Clockwork/Storage/SqlSearch.php
@@ -23,7 +23,7 @@ class SqlSearch extends Search
 	}
 
 	// Creates a new isntance from a base Search class instance
-	public static function fromBase(Search $search)
+	public static function fromBase(Search $search = null)
 	{
 		return new static((array) $search);
 	}


### PR DESCRIPTION
Sets a default value of null in SqlSearch::fromBase().

Should prevent errors in SqlStorage where a null value might be passed.

An alternative implementation could be to apply a default value in `SqlStorage`, e.g.:

```php
if (null === $search) {
    $search = new Search;
}
```