### PR TITLE
Sets a default value of null in SqlSearch::fromBase().

### DIFF
--- a/Clockwork/Storage/SqlSearch.php
+++ b/Clockwork/Storage/SqlSearch.php
@@ -23,7 +23,7 @@ class SqlSearch extends Search
 	}
 
 	// Creates a new isntance from a base Search class instance
-	public static function fromBase(Search $search)
+	public static function fromBase(Search $search = null)
 	{
 		return new static((array) $search);
 	}


### PR DESCRIPTION
Should prevent errors in SqlStorage where a null value might be passed.

An alternative implementation might be to apply a default in `SqlStorage`:

```php
if ($search === null) {
    $search = new Search;
}
```

Let me know what you think.