### PR TITLE
Ensure correct mime types for json and png files in web ui

### DIFF
--- a/Clockwork/Web/Web.php
+++ b/Clockwork/Web/Web.php
@@ -13,6 +13,8 @@ class Web
 		switch (pathinfo($path, PATHINFO_EXTENSION)) {
 			case 'css': $mime = 'text/css'; break;
 			case 'js': $mime = 'application/javascript'; break;
+			case 'json': $mime = 'application/json'; break;
+			case 'png': $mime = 'image/png'; break;
 			default: $mime = 'text/html'; break;
 		}
 


### PR DESCRIPTION
Currently, manifest.json and all images are served with text/html content type.

Verified with v5.1.0 using the laravel integration.