### PR TITLE
When displaying database queries, do not add quotes around integer params

### DIFF
--- a/Clockwork/DataSource/EloquentDataSource.php
+++ b/Clockwork/DataSource/EloquentDataSource.php
@@ -269,6 +269,10 @@ class EloquentDataSource extends DataSource
 			return "'" . str_replace("'", "''", $binding) . "'";
 		}
 
+		if (is_int($binding)) {
+			return $binding;
+		}
+
 		return $pdo->quote($binding);
 	}
 


### PR DESCRIPTION
I have noticed that Clockwork always prints database query parameters with quotes, even if the query is run with an integer that does not require quotes.

For example, with a Laravel Query:
```php
User::where('id', 123)->first()
```

This query incorrectly logs as:
```sql
SELECT * FROM users WHERE id = '123'
```

It should be logged as:
```sql
SELECT * FROM users WHERE id = 123
```

This patch will check if the value is an integer and only apply the quotes if `is_int` returns false. This logic matches what is used in the [Laravel framework query builder](https://github.com/laravel/framework/blob/v8.61.0/src/Illuminate/Database/Connection.php#L603).