### PR TITLE
Avoid deprecation notice in php 8.1

### DIFF
--- a/Clockwork/DataSource/PhpDataSource.php
+++ b/Clockwork/DataSource/PhpDataSource.php
@@ -114,7 +114,7 @@ class PhpDataSource extends DataSource
 		$port = (! $https && $port != 80 || $https && $port != 443) ? ":{$port}" : '';
 
 		// remove port number from the host
-		$host = preg_replace('/:\d+$/', '', trim($host));
+		$host = $host ? preg_replace('/:\d+$/', '', trim($host)) : null;
 
 		return "{$scheme}://{$host}{$port}{$uri}";
 	}


### PR DESCRIPTION
With PHP 8.1, I get this deprecation notice for cli commands:

> trim(): Passing null to parameter #1 ($string) of type string is deprecated