### PR TITLE
Laravel - fix collecting queries with bindings including question marks

### DIFF
--- a/Clockwork/DataSource/EloquentDataSource.php
+++ b/Clockwork/DataSource/EloquentDataSource.php
@@ -231,17 +231,16 @@ class EloquentDataSource extends DataSource
 		// add bindings to query
 		$bindings = $this->databaseManager->connection($connection)->prepareBindings($bindings);
 
-		foreach ($bindings as $binding) {
-			$binding = $this->quoteBinding($binding, $connection);
+		$index = 0;
+		$query = preg_replace_callback('/\?/', function ($matches) use ($bindings, $connection, &$index) {
+			$binding = $this->quoteBinding($bindings[$index++], $connection);
 
 			// convert binary bindings to hexadecimal representation
 			if (! preg_match('//u', $binding)) $binding = '0x' . bin2hex($binding);
 
 			// escape backslashes in the binding (preg_replace requires to do so)
-			$binding = str_replace('\\', '\\\\', $binding);
-
-			$query = preg_replace('/\?/', $binding, $query, 1);
-		}
+			return str_replace('\\', '\\\\', $binding);
+		}, $query, count($bindings));
 
 		// highlight keywords
 		$keywords = [


### PR DESCRIPTION
- fixed invalid queries being collected with multiple bindings where one of the bindings includes question mark by changing how we create runnable queries
