### PR TITLE
Timeline - return closure return value when calling event run api

### DIFF
--- a/Clockwork/Request/Timeline/Event.php
+++ b/Clockwork/Request/Timeline/Event.php
@@ -46,14 +46,16 @@ class Event
 		return $this;
 	}
 
-	// Begin the event, execute the passed in closure and end the event
+	// Begin the event, execute the passed in closure and end the event, returns the closure return value
 	public function run(\Closure $closure)
 	{
 		$this->begin();
 
-		$closure();
+		$result = $closure();
 
-		return $this->end();
+		$this->end();
+
+		return $result;
 	}
 
 	// Set or retrieve event duration (in ms), event can be defined with both start and end time or just a single time and duration


### PR DESCRIPTION
Event run method now returns the return value of the closure instead of the event instance.

```php
// Before
$value = clock()->event('Sample Event')->run(fn() => 'foo');
$value; // Clockwork\Request\Timeline\Event instance

// After
$value = clock()->event('Sample Event')->run(fn() => 'foo');
$value; // foo
```

This is a minor breaking change.
