### PR TITLE
Fix symfony warnings

### DIFF
--- a/Clockwork/Support/Symfony/ClockworkBundle.php
+++ b/Clockwork/Support/Symfony/ClockworkBundle.php
@@ -4,6 +4,9 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class ClockworkBundle extends Bundle
 {
+	/**
+	 * {@inheritdoc}
+	 */
 	protected function getContainerExtensionClass()
 	{
 		return ClockworkExtension::class;


### PR DESCRIPTION
```
[info] User Deprecated: Method "Symfony\Component\HttpKernel\Bundle\Bundle::getContainerExtensionClass()" might add "string" as a native return type declaration in the future. Do the same in child class "Clockwork\Support\Symfony\ClockworkBundle" now to avoid errors or add an explicit @return annotation to suppress this message.
```