### PR TITLE
Fix "updateToken" leak via "only" filter

### DIFF
--- a/Clockwork/Support/Laravel/ClockworkSupport.php
+++ b/Clockwork/Support/Laravel/ClockworkSupport.php
@@ -78,10 +78,10 @@ class ClockworkSupport
 
 		if (is_array($data)) {
 			$data = array_map(function ($request) use ($except, $only) {
-				return $only ? $request->only($only) : $request->except(array_merge($except, [ 'updateToken' ]));
+				return $only ? $request->only(array_diff($only, [ 'updateToken' ])) : $request->except(array_merge($except, [ 'updateToken' ]));
 			}, $data);
 		} elseif ($data) {
-			$data = $only ? $data->only($only) : $data->except(array_merge($except, [ 'updateToken' ]));
+			$data = $only ? $data->only(array_diff($only, [ 'updateToken' ])) : $data->except(array_merge($except, [ 'updateToken' ]));
 		}
 
 		return new JsonResponse($data);


### PR DESCRIPTION
You can currently get the `updateToken` for a request using the `only` filter, e.g.:

https://example.com/__clockwork/1639421586-1365-145318619?only=updateToken

Not a huge deal since clockwork should be running on a dev machine or with auth enabled if on a public server. And even if that isn't the case this only allows you to update the `clientMetrics` and `webVitals` fields.