### PR TITLE
Don't use PSR-3 abstract logger

### DIFF
--- a/Clockwork/Request/Log.php
+++ b/Clockwork/Request/Log.php
@@ -4,11 +4,11 @@ use Clockwork\Helpers\Serializer;
 use Clockwork\Helpers\StackTrace;
 use Clockwork\Helpers\StackFilter;
 
-use Psr\Log\AbstractLogger;
 use Psr\Log\LogLevel;
+use Psr\Log\LoggerInterface;
 
 // Data structure representing a log with timestamped messages
-class Log extends AbstractLogger
+class Log implements LoggerInterface
 {
 	// Array of logged messages
 	public $messages = [];
@@ -33,6 +33,46 @@ class Log extends AbstractLogger
 			'time'      => microtime(true),
 			'trace'     => (new Serializer(! empty($context['trace']) ? [ 'traces' => true ] : []))->trace($trace)
 		];
+	}
+
+	public function emergency($message, array $context = [])
+	{
+		$this->log(LogLevel::EMERGENCY, $message, $context);
+	}
+
+	public function alert($message, array $context = [])
+	{
+		$this->log(LogLevel::ALERT, $message, $context);
+	}
+
+	public function critical($message, array $context = [])
+	{
+		$this->log(LogLevel::CRITICAL, $message, $context);
+	}
+
+	public function error($message, array $context = [])
+	{
+		$this->log(LogLevel::ERROR, $message, $context);
+	}
+
+	public function warning($message, array $context = [])
+	{
+		$this->log(LogLevel::WARNING, $message, $context);
+	}
+
+	public function notice($message, array $context = [])
+	{
+		$this->log(LogLevel::NOTICE, $message, $context);
+	}
+
+	public function info($message, array $context = [])
+	{
+		$this->log(LogLevel::INFO, $message, $context);
+	}
+
+	public function debug($message, array $context = [])
+	{
+		$this->log(LogLevel::DEBUG, $message, $context);
 	}
 
 	// Merge another log instance into the current log


### PR DESCRIPTION
We were using the PSR-3 abstract log for the convenience methods for specific log levels (info, warning, error, etc.). With psr/log 2.0 the abstract class now includes a string type-hint for the message, which is too specific as we allow any data type to be logged. Solved by duplicating the convenience methods in our logger class without the type-hint.