### PR TITLE
fix: Passing null to parameter #1 in strpos()

### DIFF
--- a/Clockwork/Helpers/StackFilter.php
+++ b/Clockwork/Helpers/StackFilter.php
@@ -126,13 +126,13 @@ class StackFilter
 	protected function matchesNamespace(StackFrame $frame)
 	{
 		foreach ($this->notNamespaces as $namespace) {
-			if (strpos($frame->class, "{$namespace}\\") !== false) return false;
+			if ($frame->class !== null && strpos($frame->class, "{$namespace}\\") !== false) return false;
 		}
 
 		if (! count($this->namespaces)) return true;
 
 		foreach ($this->namespaces as $namespace) {
-			if (strpos($frame->class, "{$namespace}\\") !== false) return true;
+			if ($frame->class !== null && strpos($frame->class, "{$namespace}\\") !== false) return true;
 		}
 
 		return false;


### PR DESCRIPTION
Without this PR and on PHP 8.1, I'm getting the below warning:

`strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in .../vendor/itsgoingd/clockwork/Clockwork/Helpers/StackFilter.php on line 129`

I added a simple null check.