### PR TITLE
v3.0 for psr/log added

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.6",
         "ext-json": "*",
-        "psr/log": "1.* || ^2.0"
+        "psr/log": "1.* || ^2.0 || ^3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Recent updates for Laravel fix the psr/log to version ^3.0. The only thing added in that version are return types, which keeps the package compatible.