### PR TITLE
Removed psr/log support

### DIFF
--- a/Clockwork/Request/Log.php
+++ b/Clockwork/Request/Log.php
@@ -4,11 +4,8 @@ use Clockwork\Helpers\Serializer;
 use Clockwork\Helpers\StackTrace;
 use Clockwork\Helpers\StackFilter;
 
-use Psr\Log\LogLevel;
-use Psr\Log\LoggerInterface;
-
 // Data structure representing a log with timestamped messages
-class Log implements LoggerInterface
+class Log
 {
 	// Array of logged messages
 	public $messages = [];

--- a/Clockwork/Request/LogLevel.php
+++ b/Clockwork/Request/LogLevel.php
@@ -1,0 +1,13 @@
+<?php namespace Clockwork\Request;
+
+class LogLevel
+{
+	const EMERGENCY = 'emergency';
+	const ALERT     = 'alert';
+	const CRITICAL  = 'critical';
+	const ERROR     = 'error';
+	const WARNING   = 'warning';
+	const NOTICE    = 'notice';
+	const INFO      = 'info';
+	const DEBUG     = 'debug';
+}

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,7 @@
     ],
     "require": {
         "php": ">=5.6",
-        "ext-json": "*",
-        "psr/log": "1.* || ^2.0"
+        "ext-json": "*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- removed psr/log support, as the latest version adds incompatible type-hints and causes installation issues on Laravel 9
- the logger class api is unchanged, just no longer implements the psr interface
- fixes https://github.com/itsgoingd/clockwork/issues/562

### Breaking

- `Clockwork\Request\Log` no longer implements the PSR log interface, it is unlikely you are using this class directly
