### PR TITLE
Improve the readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Clockwork also collects stack traces for data like log messages or database quer
 
 ##### Web interface
 
-Open `your.app/clockwork` to view and interact with the collected data.
+Visit `/clockwork` route to view and interact with the collected data.
 
 The app will show all executed requests, which is useful when the request is not made by browser, but for example a mobile application you are developing an API for.
 


### PR DESCRIPTION
When I read this line I thought that I must visit `/app/clockwork` and after lots of tries I found out that you mean `your_app_url/clockwork` So, I think this way is better