### PR TITLE
Add quotes around field names in where clause

### DIFF
--- a/Clockwork/Storage/SqlSearch.php
+++ b/Clockwork/Storage/SqlSearch.php
@@ -71,10 +71,10 @@ class SqlSearch extends Search
 			return implode(' OR ', array_map(function ($input, $index) use ($field, &$bindings) {
 				if (preg_match('/^<(.+)$/', $input, $match)) {
 					$bindings["{$field}{$index}"] = $match[1];
-					return "{$field} < :{$field}{$index}";
+					return "\"{$field}\" < :{$field}{$index}";
 				} elseif (preg_match('/^>(.+)$/', $input, $match)) {
 					$bindings["{$field}{$index}"] = $match[1];
-					return "{$field} > :{$field}{$index}";
+					return "\"{$field}\" > :{$field}{$index}";
 				}
 			}, $inputs, array_keys($inputs)));
 		}, $fields));
@@ -95,7 +95,7 @@ class SqlSearch extends Search
 			}, $inputs, array_keys($inputs)));
 		}, $fields));
 
-		return [ "{$field} IN ({$values})", $bindings ];
+		return [ "\"{$field}\" IN ({$values})", $bindings ];
 	}
 
 	// Resolve a number type condition and bindings
@@ -108,17 +108,17 @@ class SqlSearch extends Search
 			return implode(' OR ', array_map(function ($input, $index) use ($field, &$bindings) {
 				if (preg_match('/^<(\d+(?:\.\d+)?)$/', $input, $match)) {
 					$bindings["{$field}{$index}"] = $match[1];
-					return "{$field} < :{$field}{$index}";
+					return "\"{$field}\" < :{$field}{$index}";
 				} elseif (preg_match('/^>(\d+(?:\.\d+)?)$/', $input, $match)) {
 					$bindings["{$field}{$index}"] = $match[1];
-					return "{$field} > :{$field}{$index}";
+					return "\"{$field}\" > :{$field}{$index}";
 				} elseif (preg_match('/^(\d+(?:\.\d+)?)-(\d+(?:\.\d+)?)$/', $input, $match)) {
 					$bindings["{$field}{$index}from"] = $match[1];
 					$bindings["{$field}{$index}to"] = $match[2];
-					return "({$field} > :{$field}{$index}from AND {$field} < :{$field}{$index}to)";
+					return "(\"{$field}\" > :{$field}{$index}from AND \"{$field}\" < :{$field}{$index}to)";
 				} else {
 					$bindings["{$field}{$index}"] = $input;
-					return "{$field} = :{$field}{$index}";
+					return "\"{$field}\" = :{$field}{$index}";
 				}
 			}, $inputs, array_keys($inputs)));
 		}, $fields));
@@ -135,7 +135,7 @@ class SqlSearch extends Search
 		$conditions = implode(' OR ', array_map(function ($field) use ($inputs, &$bindings) {
 			return implode(' OR ', array_map(function ($input, $index) use ($field, &$bindings) {
 				$bindings["{$field}{$index}"] = $input;
-				return "{$field} LIKE :{$field}{$index}";
+				return "\"{$field}\" LIKE :{$field}{$index}";
 			}, $inputs, array_keys($inputs)));
 		}, $fields));
 


### PR DESCRIPTION
This pull request fixes #578  and #579.
It adds quotes around fields/column names in `where` clause.

I tested it only with PostgresSQL 13.5.
Maybe someone can verify it with MySQL.