### PR TITLE
Add support for abbreviated artisan commands such as the usage of `ca…

### DIFF
--- a/Clockwork/Support/Laravel/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Laravel/ClockworkServiceProvider.php
@@ -29,6 +29,7 @@ class ClockworkServiceProvider extends ServiceProvider
 			$this->registerMiddleware();
 		}
 
+		$this->app['clockwork.support']->handleArtisanEvents();
 		$this->app['clockwork.support']->handleOctaneEvents();
 
 		// If Clockwork is disabled, return before registering middleware or routes

--- a/Clockwork/Support/Laravel/ClockworkSupport.php
+++ b/Clockwork/Support/Laravel/ClockworkSupport.php
@@ -204,6 +204,13 @@ class ClockworkSupport
 		return $this->app['clockwork.laravel'];
 	}
 
+	public function handleArtisanEvents()
+	{
+		$this->app['events']->listen(\Illuminate\Console\Events\ArtisanStarting::class, function ($event) {
+			$this->app['clockwork.artisan'] = $event->artisan;
+		});
+	}
+
 	public function handleOctaneEvents()
 	{
 		$this->app['events']->listen(\Laravel\Octane\Events\RequestReceived::class, function ($event) {
@@ -281,7 +288,9 @@ class ClockworkSupport
 
 			if (! $event->command || $this->isCommandFiltered($event->command)) return;
 
-			$command = $this->app->make(ConsoleKernel::class)->all()[$event->command];
+			$command = $this->app->has('clockwork.artisan')
+				? $this->app['clockwork.artisan']->find($event->command)
+				: $this->app->make(ConsoleKernel::class)->all()[$event->command];
 
 			$allArguments = $event->input->getArguments();
 			$allOptions = $event->input->getOptions();


### PR DESCRIPTION
Add support for abbreviated artisan commands such as the usage of `ca:cl` for `cache:clear`.

Currently using these abbreviations will execute the command but then throw a clockwork `Undefined array key "ca:cl"` error. 