### PR TITLE
Skip accessing `$name` property when `name()` method exists

### DIFF
--- a/Clockwork/DataSource/LaravelDataSource.php
+++ b/Clockwork/DataSource/LaravelDataSource.php
@@ -204,7 +204,7 @@ class LaravelDataSource extends DataSource
 
 		$request->setAuthenticatedUser($user->email, $user->id, [
 			'email' => $user->email,
-			'name'  => isset($user->name) ? $user->name : null
+			'name'  => !method_exists($user, 'name') && isset($user->name) ? $user->name : null
 		]);
 	}
 }


### PR DESCRIPTION
Consider the following model:

```php
class User extends Model
{
    public function name()
    {
        return $this->first_name . ' ' . $this->last_name;
    }
}
```

When Clockwork tries to collect information about this user, it accesses the `$name` property. Laravel assumes you're trying to call the `name` relationship defined in the `name()` method (which isn't a relationship in this example). It then throws a `LogicException`: "Model::name must return a relationship instance.".

By checking the `user()` method doesn't exist this exception can be avoided.