### PR TITLE
Two convenience improvements to the `Event` class when using closures

### DIFF
--- a/Clockwork/Request/Timeline/Event.php
+++ b/Clockwork/Request/Timeline/Event.php
@@ -50,12 +50,11 @@ class Event
 	public function run(\Closure $closure)
 	{
 		$this->begin();
-
-		$result = $closure();
-
-		$this->end();
-
-		return $result;
+		try {
+			return $closure();
+		} finally {
+			$this->end();
+		}
 	}
 
 	// Set or retrieve event duration (in ms), event can be defined with both start and end time or just a single time and duration

--- a/Clockwork/Request/Timeline/Event.php
+++ b/Clockwork/Request/Timeline/Event.php
@@ -47,11 +47,11 @@ class Event
 	}
 
 	// Begin the event, execute the passed in closure and end the event, returns the closure return value
-	public function run(\Closure $closure)
+	public function run(\Closure $closure, ...$args)
 	{
 		$this->begin();
 		try {
-			return $closure();
+			return $closure(...$args);
 		} finally {
 			$this->end();
 		}


### PR DESCRIPTION
The first one just ensure that `end()` is called even when the closure throws an exception.

The second one allows passing additional arguments which are simply forwarded to the closure.
