### PR TITLE
Fix PHP 8.2 dynamic property deprecated

### DIFF
--- a/Clockwork/DataSource/EloquentDataSource.php
+++ b/Clockwork/DataSource/EloquentDataSource.php
@@ -17,6 +17,9 @@ class EloquentDataSource extends DataSource
 	// Database manager instance
 	protected $databaseManager;
 
+	// Event dispatcher instance
+	protected $eventDispatcher;
+
 	// Array of collected queries
 	protected $queries = [];
 

--- a/Clockwork/Request/Request.php
+++ b/Clockwork/Request/Request.php
@@ -80,6 +80,7 @@ class Request
 	public $databaseUpdates;
 	public $databaseDeletes;
 	public $databaseOthers;
+	public $databaseDuration;
 
 	// Cache queries
 	public $cacheQueries = [];


### PR DESCRIPTION
This PR fixes the `Creation of dynamic property` bug in PHP 8.2.