### PR TITLE
fix: avoid initialisation of storage if not enabled

### DIFF
--- a/Clockwork/Support/Laravel/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Laravel/ClockworkServiceProvider.php
@@ -73,7 +73,13 @@ class ClockworkServiceProvider extends ServiceProvider
 	protected function registerClockwork()
 	{
 		$this->app->singleton('clockwork', function ($app) {
-			return (new Clockwork)
+			$clockwork = new Clockwork;
+
+			if ($app['clockwork.support']->isEnabled()) {
+				return $clockwork;
+			}
+
+			return $clockwork
 				->authenticator($app['clockwork.authenticator'])
 				->request($app['clockwork.request'])
 				->storage($app['clockwork.storage']);


### PR DESCRIPTION
I noticed that even if Clockwork is disabled, it tries to establish a connection to the database. This PR disables the behaviour.