### PR TITLE
Storage - Allow compatibility with log collector like filebeat

### DIFF
--- a/Clockwork/Storage/FileStorage.php
+++ b/Clockwork/Storage/FileStorage.php
@@ -86,7 +86,7 @@ class FileStorage extends Storage
 
 		$this->compress
 			? file_put_contents("{$path}.gz", gzcompress($data))
-			: file_put_contents($path, $data);
+			: file_put_contents($path, $data . PHP_EOL);
 
 		if (! $skipIndex) $this->updateIndex($request);
 


### PR DESCRIPTION
https://github.com/itsgoingd/clockwork/issues/652

Filebeat needs an end of line to detect that the log is ready to be collected.
As Clockwork write 1 log by file, Filebeat never collects what's inside a json file except if we add an EOL.

(He is watching the file but believes that the log message/data is uncomplete)