### PR TITLE
Add missing `expiration` to cache record

### DIFF
--- a/Clockwork/DataSource/LaravelCacheDataSource.php
+++ b/Clockwork/DataSource/LaravelCacheDataSource.php
@@ -104,6 +104,7 @@ class LaravelCacheDataSource extends DataSource
 		$record = [
 			'type'       => $query['type'],
 			'key'        => $query['key'],
+			'expiration' => $query['expiration'] ?? null,
 			'time'       => microtime(true),
 			'connection' => null,
 			'trace'      => (new Serializer)->trace($trace)


### PR DESCRIPTION
This will show the value for "Expires" in the records table in the Cache tab like so:

<table>
  <thead>
  <tr>
    <th width="50%">Before</th>
    <th width="50%">After</th>
  </tr>
  </thead>
  <tbody>
  <tr>
    <td valign="top"><img src="https://github.com/itsgoingd/clockwork/assets/7470739/00a5d227-7b74-42e8-b04e-d1e96f06aa93"></td>
    <td valign="top"><img src="https://github.com/itsgoingd/clockwork/assets/7470739/7f2d5d69-d7ed-4ad0-9fb9-b85a2c546250"></td>
  </tr>
  </tbody>
</table>