### PR TITLE
Remove `$` prefix from install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 Install the Clockwork library via [Composer](https://getcomposer.org/).
 
 ```
-$ composer require itsgoingd/clockwork
+composer require itsgoingd/clockwork
 ```
 
 Congratulations, you are done! To enable more features like commands or queue jobs profiling, publish the configuration file via the `vendor:publish` Artisan command.


### PR DESCRIPTION
Very minor inconvenience but I pressed the 'Copy' button and it included the `$` so the command can't be ran immediately. I would suggest getting rid of this $ symbol so it can easily be copied and pasted into terminals