### PR TITLE
Add missing `__clockwork/lastest` implementation for Slim frameworks

### DIFF
--- a/Clockwork/Support/Slim/ClockworkMiddleware.php
+++ b/Clockwork/Support/Slim/ClockworkMiddleware.php
@@ -36,7 +36,7 @@ class ClockworkMiddleware
 			return $this->authenticate($request);
 		}
 
-		$clockworkDataUri = '#/__clockwork(?:/(?<id>[0-9-]+))?(?:/(?<direction>(?:previous|next)))?(?:/(?<count>\d+))?#';
+		$clockworkDataUri = '#/__clockwork(?:/(?<id>([0-9-]+|latest)))?(?:/(?<direction>(?:previous|next)))?(?:/(?<count>\d+))?#';
 		if (preg_match($clockworkDataUri, $request->getUri()->getPath(), $matches)) {
 			$matches = array_merge([ 'id' => null, 'direction' => null, 'count' => null ], $matches);
 			return $this->retrieveRequest($request, $matches['id'], $matches['direction'], $matches['count']);

--- a/Clockwork/Support/Slim/Legacy/ClockworkMiddleware.php
+++ b/Clockwork/Support/Slim/Legacy/ClockworkMiddleware.php
@@ -34,7 +34,7 @@ class ClockworkMiddleware
 			return $this->authenticate($response, $request);
 		}
 
-		$clockworkDataUri = '#/__clockwork(?:/(?<id>[0-9-]+))?(?:/(?<direction>(?:previous|next)))?(?:/(?<count>\d+))?#';
+		$clockworkDataUri = '#/__clockwork(?:/(?<id>([0-9-]+|latest)))?(?:/(?<direction>(?:previous|next)))?(?:/(?<count>\d+))?#';
 		if (preg_match($clockworkDataUri, $request->getUri()->getPath(), $matches)) {
 			$matches = array_merge([ 'id' => null, 'direction' => null, 'count' => null ], $matches);
 			return $this->retrieveRequest($response, $request, $matches['id'], $matches['direction'], $matches['count']);

--- a/Clockwork/Support/Slim/Old/ClockworkMiddleware.php
+++ b/Clockwork/Support/Slim/Old/ClockworkMiddleware.php
@@ -39,7 +39,7 @@ class ClockworkMiddleware extends Middleware
 
 		$this->app->getLog()->setWriter($clockworkLogWriter);
 
-		$clockworkDataUri = '#/__clockwork(?:/(?<id>[0-9-]+))?(?:/(?<direction>(?:previous|next)))?(?:/(?<count>\d+))?#';
+		$clockworkDataUri = '#/__clockwork(?:/(?<id>([0-9-]+|latest)))?(?:/(?<direction>(?:previous|next)))?(?:/(?<count>\d+))?#';
 		if ($this->app->config('debug') && preg_match($clockworkDataUri, $this->app->request()->getPathInfo(), $matches)) {
 			$matches = array_merge([ 'direction' => null, 'count' => null ], $matches);
 			return $this->retrieveRequest($matches['id'], $matches['direction'], $matches['count']);


### PR DESCRIPTION
This should fix #576.

In addition, this fixes a small glitch in the Symfony support. There, it allowed lowercase letters (a-z) as part of the record ID. The IDs should only consist of numbers and `-` (hyphen / minus) though.
