### PR TITLE
Fix bug in SQL-based search

### DIFF
--- a/Clockwork/Storage/SqlSearch.php
+++ b/Clockwork/Storage/SqlSearch.php
@@ -54,7 +54,7 @@ class SqlSearch extends Search
 			$this->resolveStringCondition([ 'type' ], $this->type),
 			$this->resolveStringCondition([ 'uri', 'commandName', 'jobName', 'testName' ], array_merge($this->uri, $this->name)),
 			$this->resolveStringCondition([ 'controller' ], $this->controller),
-			$this->resolveExactCondition([ 'method' ], $this->method),
+			$this->resolveExactCondition('method', $this->method),
 			$this->resolveNumberCondition([ 'responseStatus', 'commandExitCode', 'jobStatus', 'testStatus' ], $this->status),
 			$this->resolveNumberCondition([ 'responseDuration' ], $this->time),
 			$this->resolveDateCondition([ 'time' ], $this->received)
@@ -90,17 +90,19 @@ class SqlSearch extends Search
 	}
 
 	// Resolve an exact type condition and bindings
-	protected function resolveExactCondition($fields, $inputs)
+	protected function resolveExactCondition($field, $inputs)
 	{
 		if (! count($inputs)) return null;
 
 		$bindings = [];
-		$values = implode(' OR ', array_map(function ($field) use ($inputs, &$bindings) {
-			return implode(', ', array_map(function ($input, $index) use ($field, &$bindings) {
+		$values = implode(', ', array_map(
+			static function ($input, $index) use ($field, &$bindings) {
 				$bindings["{$field}{$index}"] = $input;
 				return ":{$field}{$index}";
-			}, $inputs, array_keys($inputs)));
-		}, $fields));
+			},
+			$inputs,
+			array_keys($inputs)
+		));
 
 		return [ $this->quote($field) . " IN ({$values})", $bindings ];
 	}


### PR DESCRIPTION
Using PHPStan static analyzer, it found an undefined variable `$field` in `SqlSearch::resolveExactCondition()`. This bug is a remnant from a refactoring that took place in #361.

The attached commit should fix that and reduce the complexity of the code a bit.
