### PR TITLE
fix(#676): allow monolog datasource to set the correct handler

### DIFF
--- a/Clockwork/DataSource/MonologDataSource.php
+++ b/Clockwork/DataSource/MonologDataSource.php
@@ -3,9 +3,11 @@
 use Clockwork\DataSource\DataSource;
 use Clockwork\Request\Log;
 use Clockwork\Request\Request;
-use Clockwork\Support\Monolog\Handler\ClockworkHandler;
-
+use Clockwork\Support\Monolog\Monolog2\ClockworkHandler;
+use Clockwork\Support\Monolog\Monolog\ClockworkHandler as MonologClockworkHandler;
+use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Logger as Monolog;
+use ReflectionMethod;
 
 // Data source for Monolog, provides application log
 class MonologDataSource extends DataSource
@@ -18,7 +20,17 @@ class MonologDataSource extends DataSource
 	{
 		$this->log = new Log;
 
-		$monolog->pushHandler(new ClockworkHandler($this->log));
+		/**
+		 * Use `Clockwork\Support\Monolog\Monolog2\ClockworkHandler`
+		 * when the method `AbstractProcessingHandler::write` has a return type
+		 * Because Monolog 2 introduced scalar type hints and return hints
+		 */
+		$writeMethod = new ReflectionMethod(AbstractProcessingHandler::class, 'write');
+		if ($writeMethod->hasReturnType()) {
+			$monolog->pushHandler(new ClockworkHandler($this->log));
+		} else {
+			$monolog->pushHandler(new MonologClockworkHandler($this->log));
+		}
 	}
 
 	// Adds log entries to the request


### PR DESCRIPTION
This PR solve the ticket #676 by setting the correct handler in the existing `Clockwork\DataSource\MonologDataSource` by checking whether the `AbstractProcessingHandler:write` has a return type.