### PR TITLE
Add alias `clockwork:clear` to ClockworkCleanCommand

### DIFF
--- a/Clockwork/Support/Laravel/ClockworkCleanCommand.php
+++ b/Clockwork/Support/Laravel/ClockworkCleanCommand.php
@@ -12,6 +12,11 @@ class ClockworkCleanCommand extends Command
 	// Command description
 	protected $description = 'Cleans Clockwork request metadata';
 
+	// Command aliases
+	protected $aliases = [
+		'clockwork:clear',
+	];
+
 	// Command options
 	public function getOptions()
 	{


### PR DESCRIPTION
This PR adds an alias to the `clockwork:clean` command so it better aligns with the existing `*:clear` commands that Laravel provides.

Some examples of the `*:clear` commands that Laravel provides are:

`cache:clear`
`config:clear`
`optimize:clear`
`queue:clear`
`route:clear`
`view:clear`