### PR TITLE
Vanilla - added generic PSR-compatible middleware

### DIFF
--- a/Clockwork/Request/IncomingRequest.php
+++ b/Clockwork/Request/IncomingRequest.php
@@ -8,6 +8,9 @@ class IncomingRequest
 	// URI
 	public $uri;
 
+	// Headers
+	public $headers;
+
 	// GET and POST data
 	public $input = [];
 	// Cookies
@@ -19,6 +22,18 @@ class IncomingRequest
 	public function __construct(array $data = [])
 	{
 		foreach ($data as $key => $val) $this->$key = $val;
+	}
+
+	// Returns a header value, or default if not set
+	public function header($key, $default = null)
+	{
+		return isset($this->headers[$key]) ? $this->headers[$key] : $default;
+	}
+
+	// Returns an input value, or default if not set
+	public function input($key, $default = null)
+	{
+		return isset($this->input[$key]) ? $this->input[$key] : $default;
 	}
 
 	// Returns true, if HTTP host is one of the common domains used for local development

--- a/Clockwork/Support/Vanilla/Clockwork.php
+++ b/Clockwork/Support/Vanilla/Clockwork.php
@@ -14,10 +14,8 @@ use Clockwork\Storage\RedisStorage;
 use Clockwork\Storage\Search;
 use Clockwork\Storage\SqlStorage;
 
-use Http\Discovery\Psr17Factory;
 use Psr\Http\Message\ServerRequestInterface as PsrRequest;
 use Psr\Http\Message\ResponseInterface as PsrResponse;
-use Psr\Http\Message\ResponseFactoryInterface as PsrResponseFactory;
 
 // Clockwork integration for vanilla php and unsupported frameworks
 class Clockwork
@@ -320,14 +318,10 @@ class Clockwork
 	}
 
 	// Use a PSR-7 request and response instances instead of vanilla php HTTP apis
-	public function usePsrMessage(PsrRequest $request, PsrResponse $response = null, PsrResponseFactory $responseFactory = null)
+	public function usePsrMessage(PsrRequest $request, PsrResponse $response = null)
 	{
-		if (! $response && ! $responseFactory && ! class_exists(Psr17Factory::class)) {
-			throw new \Exception('The Clockwork vanilla integration requires a response, response factory or the php-http/discovery package to be installed.');
-		}
-
 		$this->psrRequest = $request;
-		$this->psrResponse = $response ?: ($responseFactory ?: new Psr17Factory)->createResponse();
+		$this->psrResponse = $response;
 
 		$this->clockwork->addDataSource(new PsrMessageDataSource($request, $response));
 

--- a/Clockwork/Support/Vanilla/Clockwork.php
+++ b/Clockwork/Support/Vanilla/Clockwork.php
@@ -402,10 +402,10 @@ class Clockwork
 	public function configureShouldCollect()
 	{
 		$this->clockwork->shouldCollect([
-			'onDemand'       => $this->config['requests']['on_demand'],
-			'sample'         => $this->config['requests']['sample'],
-			'except'         => $this->config['requests']['except'],
-			'only'           => $this->config['requests']['only'],
+			'onDemand'        => $this->config['requests']['on_demand'],
+			'sample'          => $this->config['requests']['sample'],
+			'except'          => $this->config['requests']['except'],
+			'only'            => $this->config['requests']['only'],
 			'exceptPreflight' => $this->config['requests']['except_preflight']
 		]);
 

--- a/Clockwork/Support/Vanilla/Clockwork.php
+++ b/Clockwork/Support/Vanilla/Clockwork.php
@@ -495,8 +495,10 @@ class Clockwork
 	// Resolves default metadata REST api request either from the URI, or the request query parameter
 	protected function defaultMetadataRequest()
 	{
+		$apiPath = $this->config['api'];
+
 		if ($request = $this->incomingRequest()->input('request')) return $request;
-		if (preg_match('#^/__clockwork/(.*)#', $this->incomingRequest()->uri, $matches)) return $matches[1];
+		if (preg_match("#^{$apiPath}(.*)#", $this->incomingRequest()->uri, $matches)) return $matches[1];
 
 		return '';
 	}
@@ -505,6 +507,12 @@ class Clockwork
 	public function getClockwork()
 	{
 		return $this->clockwork;
+	}
+
+	// Return the configuration array
+	public function getConfig()
+	{
+		return $this->config;
 	}
 
 	// Pass any method calls to the underlying Clockwork instance

--- a/Clockwork/Support/Vanilla/ClockworkMiddleware.php
+++ b/Clockwork/Support/Vanilla/ClockworkMiddleware.php
@@ -63,8 +63,10 @@ class ClockworkMiddleware implements MiddlewareInterface
 	// Handle a Clockwork REST api request if routing is enabled
 	protected function handleApiRequest(ServerRequestInterface $request)
 	{
+		$path = $this->clockwork->getConfig()['api'];
+
 		if (! $this->handleRouting) return;
-		if (! preg_match('#/__clockwork/.*#', $request->getUri()->getPath())) return; 
+		if (! preg_match("#{$path}.*#", $request->getUri()->getPath())) return;
 		
 		return $this->clockwork->usePsrMessage($request, null, $this->responseFactory)->handleMetadata();
 	}
@@ -72,8 +74,10 @@ class ClockworkMiddleware implements MiddlewareInterface
 	// Handle a Clockwork Web interface request if routing is enabled
 	protected function handleWebRequest(ServerRequestInterface $request)
 	{
+		$path = is_string($this->clockwork->getConfig()['web']['enable']) ? $this->clockwork->getConfig()['web']['enable'] : '/clockwork';
+
 		if (! $this->handleRouting) return;
-		if ($request->getUri()->getPath() != '/clockwork') return; 
+		if ($request->getUri()->getPath() != $path) return;
 
 		return $this->clockwork->usePsrMessage($request, null, $this->responseFactory)->returnWeb();
 	}

--- a/Clockwork/Support/Vanilla/ClockworkMiddleware.php
+++ b/Clockwork/Support/Vanilla/ClockworkMiddleware.php
@@ -1,0 +1,80 @@
+<?php namespace Clockwork\Support\Vanilla;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+// Generic Clockwork middleware fro use with PSR-compatible applications
+class ClockworkMiddleware implements MiddlewareInterface
+{
+	// The underlying vanilla Clockwork support class instance
+	protected $clockwork;
+
+	// Whether this middleware should handle routing for Clockwork REST api and Web interface
+	protected $handleRouting = true;
+	
+	// PSR-17 request factory instance
+	protected $responseFactory;
+	
+	// Creates new middleware instance, takes a vanilla Clockwork support class instance as an argument
+	public function __construct(Clockwork $clockwork)
+	{
+		$this->clockwork = $clockwork;
+	}
+	
+	// Returns a new middleware instance with a default singleton Clockwork instance, takes an additional configuration as argument
+	public static function init($config = [])
+	{
+		return new static(Clockwork::init($config));
+	}
+	
+	// Sets a PSR-17 compatible response factory. When using the middleware with routing enabled, response factory must be manually set
+	// or the php-http/discovery has to be intalled for zero-configuration use
+	public function withResponseFactory(ResponseFactoryInterface $responseFactory)
+	{
+		$this->responseFactory = $responseFactory;
+		return $this;
+	}
+	
+	// Disables routing handling in the middleware. When disabled additional manual configuration of the application router is required.
+	public function withoutRouting()
+	{
+		$this->handleRouting = false;
+		return $this;
+	}
+	
+	// Process the middleware
+	public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) :ResponseInterface
+	{
+		$request->withAttribute('clockwork', $this->clockwork);
+		
+		$this->clockwork->event('Controller')->begin();
+
+		if ($response = $this->handleApiRequest($request)) return $response;
+		if ($response = $this->handleWebRequest($request)) return $response;
+
+		$response = $handler->handle($request);
+
+		return $this->clockwork->usePsrMessage($request, $response)->requestProcessed();
+	}
+
+	// Handle a Clockwork REST api request if routing is enabled
+	protected function handleApiRequest(ServerRequestInterface $request)
+	{
+		if (! $this->handleRouting) return;
+		if (! preg_match('#/__clockwork/.*#', $request->getUri()->getPath())) return; 
+		
+		return $this->clockwork->usePsrMessage($request, null, $this->responseFactory)->handleMetadata();
+	}
+
+	// Handle a Clockwork Web interface request if routing is enabled
+	protected function handleWebRequest(ServerRequestInterface $request)
+	{
+		if (! $this->handleRouting) return;
+		if ($request->getUri()->getPath() != '/clockwork') return; 
+
+		return $this->clockwork->usePsrMessage($request, null, $this->responseFactory)->returnWeb();
+	}
+}

--- a/Clockwork/Support/Vanilla/ClockworkMiddleware.php
+++ b/Clockwork/Support/Vanilla/ClockworkMiddleware.php
@@ -6,7 +6,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
-// Generic Clockwork middleware fro use with PSR-compatible applications
+// Generic Clockwork middleware for use with PSR-compatible applications
 class ClockworkMiddleware implements MiddlewareInterface
 {
 	// The underlying vanilla Clockwork support class instance
@@ -48,7 +48,7 @@ class ClockworkMiddleware implements MiddlewareInterface
 	// Process the middleware
 	public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) :ResponseInterface
 	{
-		$request->withAttribute('clockwork', $this->clockwork);
+		$request = $request->withAttribute('clockwork', $this->clockwork);
 		
 		$this->clockwork->event('Controller')->begin();
 

--- a/Clockwork/Support/Vanilla/config.php
+++ b/Clockwork/Support/Vanilla/config.php
@@ -128,7 +128,7 @@ return [
 		'enable' => getenv('CLOCKWORK_WEB_ENABLE') !== false ? getenv('CLOCKWORK_WEB_ENABLE') : true,
 
 		// Path where to install the Web UI assets, should be publicly accessible
-		'path' => getenv('CLOCKWORK_WEB_PATH') !== false ? getenv('CLOCKWORK_WEB_PATH') : __DIR__ . '/../../../../../public/vendor/clockwork',
+		'path' => getenv('CLOCKWORK_WEB_PATH') !== false ? getenv('CLOCKWORK_WEB_PATH') : __DIR__ . '/../../../../../../public/vendor/clockwork',
 
 		// Public URI where the installed Web UI assets will be accessible
 		'uri' => getenv('CLOCKWORK_WEB_URI') !== false ? getenv('CLOCKWORK_WEB_URI') : '/vendor/clockwork',

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
 		"ext-pdo_sqlite": "Needed in order to use a SQLite for metadata storage",
 		"ext-pdo_mysql": "Needed in order to use MySQL for metadata storage",
 		"ext-pdo_postgres": "Needed in order to use Postgres for metadata storage",
-		"ext-redis": "Needed in order to use Redis for metadata storage"
+		"ext-redis": "Needed in order to use Redis for metadata storage",
+		"php-http/discovery": "Vanilla integration - required for the middleware zero-configuration setup"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- Adds a generic PSR-compatible middleware to the vanilla integration.
- For use with applications and frameworks implementing [PSR-15](https://www.php-fig.org/psr/psr-15/) (and by extension [PSR-7](https://www.php-fig.org/psr/psr-7) and [PSR-17](https://www.php-fig.org/psr/psr-17)), eg. [Slim](https://www.slimframework.com), [Mezzio](https://docs.mezzio.dev), etc.
- Also improves the overall vanilla integration - using PSR request instead of globals if specified, allowing to set or auto-detect a PSR response factory.
- To allow the vanilla integration to generate responses a PSR-compatible response factory has to be provided, or the `php-http/discovery` has to be installed for zero-configuration use.
- This will replace the Slim-specific integration in a future major version.
- Based on an earlier [PR](https://github.com/itsgoingd/clockwork/pull/680) by @UlrichEckhardt and a [PR](https://github.com/itsgoingd/clockwork/pull/675) by @DominicDetta

Example use in a Slim application:

```php
use Clockwork\Support\Vanilla\ClockworkMiddleware;
$app->add(ClockworkMiddleware::init()->withResponseFactory($app->getResponseFactory()));

// Run App & Emit Response
$response = $app->handle($request);
```

With the `php-http/discovery` package installed, the response factory will be auto-detected (if one is installed), making the initialization as simple as:

```php
use Clockwork\Support\Vanilla\ClockworkMiddleware;
$app->add(ClockworkMiddleware::init());
```

You can also instantiate the middleware with a custom Clockwork instance (useful if you want to register the instance with a DI container for example) and disable routing if you want to set it up on your own:

```php
use Clockwork\Support\Vanilla\Clockwork;
use Clockwork\Support\Vanilla\ClockworkMiddleware;
$clockwork = new Clockwork([ ... ]);
$app->add((new ClockworkMiddleware($clockwork))->withoutRouting());

$app->get('/__clockwork/{request:.+}', function ($request, $response) use ($clockwork) {
    return $clockwork->usePsrMessage($request, $response)->handleMetadata();
});
```

Note, because the Slim skeleton project registers the routing middleware as the last (outermost) middleware, you will need to add Clockwork middleware in `public/index.php` just before the `$app->handle()` call, instead of `app/middleware.php`.
