### PR TITLE
fix: check database/broadcast notification methods before calling

### DIFF
--- a/Clockwork/DataSource/LaravelNotificationsDataSource.php
+++ b/Clockwork/DataSource/LaravelNotificationsDataSource.php
@@ -159,8 +159,10 @@ class LaravelNotificationsDataSource extends DataSource
 			$channelSpecific = $this->resolveNexmoChannelSpecific($event, $event->notification->toNexmo($event->notifiable));
 		} elseif ($event->channel == 'broadcast') {
 			$channelSpecific = [ 'data' => [ 'data' => (new Serializer)->normalize($event->notification->toBroadcast($event->notifiable)) ] ];
-		} elseif ($event->channel == 'database') {
+		} elseif ($event->channel == 'database' && method_exists($event->notification, 'toArray')) {
 			$channelSpecific = [ 'data' => [ 'data' => (new Serializer)->normalize($event->notification->toArray($event->notifiable)) ] ];
+		} elseif ($event->channel == 'database' && method_exists($event->notification, 'toDatabase')) {
+			$channelSpecific = [ 'data' => [ 'data' => (new Serializer)->normalize($event->notification->toDatabase($event->notifiable)) ] ];
 		} else {
 			$channelSpecific = [];
 		}

--- a/Clockwork/DataSource/LaravelNotificationsDataSource.php
+++ b/Clockwork/DataSource/LaravelNotificationsDataSource.php
@@ -157,12 +157,12 @@ class LaravelNotificationsDataSource extends DataSource
 			$channelSpecific = $this->resolveSlackChannelSpecific($event, $event->notification->toSlack($event->notifiable));
 		} elseif ($event->channel == 'nexmo') {
 			$channelSpecific = $this->resolveNexmoChannelSpecific($event, $event->notification->toNexmo($event->notifiable));
-		} elseif ($event->channel == 'broadcast') {
+		} elseif ($event->channel == 'broadcast' && method_exists($event->notification, 'toBroadcast')) {
 			$channelSpecific = [ 'data' => [ 'data' => (new Serializer)->normalize($event->notification->toBroadcast($event->notifiable)) ] ];
-		} elseif ($event->channel == 'database' && method_exists($event->notification, 'toArray')) {
-			$channelSpecific = [ 'data' => [ 'data' => (new Serializer)->normalize($event->notification->toArray($event->notifiable)) ] ];
 		} elseif ($event->channel == 'database' && method_exists($event->notification, 'toDatabase')) {
 			$channelSpecific = [ 'data' => [ 'data' => (new Serializer)->normalize($event->notification->toDatabase($event->notifiable)) ] ];
+		} elseif (in_array($event->channel, ['database', 'broadcast']) && method_exists($event->notification, 'toArray')) {
+			$channelSpecific = [ 'data' => [ 'data' => (new Serializer)->normalize($event->notification->toArray($event->notifiable)) ] ];
 		} else {
 			$channelSpecific = [];
 		}


### PR DESCRIPTION
[As per Laravel Docs](https://laravel.com/docs/10.x/notifications#todatabase-vs-toarray), the Database Channel can use toDatabase and/or toArray. 

In our case, one of our broadcastable notifications had these methods separated, and later had broadcasting removed, leaving behind toDatabase(), but removing toArray(). Although the functionality still works in Laravel, it causes a break in Clockwork.

This PR checks the notification and only calls the first method that exists.

EDIT: also just learned the same of toBroadcast(). Committed a fix for that too.