### PR TITLE
Vanilla integration: Restore the default of the "enabled" flag to true

### DIFF
--- a/Clockwork/Support/Vanilla/config.php
+++ b/Clockwork/Support/Vanilla/config.php
@@ -13,7 +13,7 @@ return [
 	|
 	*/
 
-	'enable' => getenv('CLOCKWORK_ENABLE') !== false ? getenv('CLOCKWORK_ENABLE') : false,
+	'enable' => getenv('CLOCKWORK_ENABLE') !== false ? getenv('CLOCKWORK_ENABLE') : true,
 
 	/*
 	|------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This should fix #686.
