### PR TITLE
Support for collecting HTTP client requests

### DIFF
--- a/Clockwork/DataSource/GuzzleDataSource.php
+++ b/Clockwork/DataSource/GuzzleDataSource.php
@@ -1,0 +1,154 @@
+<?php namespace Clockwork\DataSource;
+
+use Clockwork\Helpers\Serializer;
+use Clockwork\Helpers\StackTrace;
+use Clockwork\Request\Request;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\TransferStats;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Promise\PromiseInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+// Data source for Guzzle HTTP client, provides executed HTTP requests
+class GuzzleDataSource extends DataSource
+{
+	// Sent HTTP requests
+	protected $requests = [];
+	
+	// Returns a new Guzzle instance, pre-configured with Clockwork support
+	public function instance(array $config = [])
+	{
+		return new Client($this->configure($config));
+	}
+	
+	// Updates Guzzle configuration array with Clockwork support
+	public function configure(array $config = [])
+	{
+		$handler = isset($config['handler']) ? $config['handler'] : HandlerStack::create();
+		
+		$handler->push($this);
+		
+		$config['handler'] = $handler;
+		
+		return $config;
+	}
+	
+	// Add sent notifications to the request
+	public function resolve(Request $request)
+	{
+		$request->httpRequests = array_merge($request->httpRequests, $this->requests);
+		
+		return $request;
+	}
+	
+	// Reset the data source to an empty state, clearing any collected data
+	public function reset()
+	{
+		$this->requests = [];
+		$this->executingRequests = [];
+	}
+	
+	// Guzzle middleware implemenation, that does the requests logging itself
+	public function __invoke(callable $handler): callable
+	{
+		return function(RequestInterface $request, array $options) use ($handler): PromiseInterface {
+			$time = microtime(true);
+			$stats = null;
+			
+			$originalOnStats = isset($options['on_stats']) ? $options['on_stats'] : null;
+			$options['on_stats'] = function (TransferStats $transferStats) use (&$stats, $originalOnStats) {
+				$stats = $transferStats->getHandlerStats();
+				if ($originalOnStats) $originalOnStats($transferStats);
+			};
+
+			return $handler($request, $options)
+				->then(function(ResponseInterface $response) use ($request, $time, $stats) {
+					$this->collectRequest($request, $response, $time, $stats);
+
+					return $response;
+				}, function(GuzzleException $exception) use ($request, $time, $stats) {
+					$response = $exception instanceof RequestException ? $exception->getResponse() : null;
+					$this->collectRequest($request, $response, $time, $stats);
+
+					throw $exception;
+				});
+		};
+	}
+	
+	// Collect a request-response pair
+	protected function collectRequest($request, $response = null, $startTime = null, $stats = null)
+	{
+		$trace = StackTrace::get();
+
+		$request = (object) [
+			'request'  => (object) [
+				'method'  => $request->getMethod(),
+				'url'     => $this->removeAuthFromUrl((string) $request->getUri()),
+				'headers' => $request->getHeaders(),
+				'content' => $this->resolveRequestContent($request),
+				'body'    => (string) $request->getBody(),
+			],
+			'response' => (object) [
+				'status'  => (int) $response->getStatusCode(),
+				'headers' => $response->getHeaders(),
+				'content' => json_decode((string) $response->getBody(), true),
+				'body'    => (string) $response->getBody()
+			],
+			'stats'    => $stats ? (object) [
+				'timing' => isset($stats['total_time_us']) ? (object) [
+					'lookup' => $stats['namelookup_time_us'] / 1000,
+					'connect' => ($stats['pretransfer_time_us'] - $stats['namelookup_time_us']) / 1000,
+					'waiting' => ($stats['starttransfer_time_us'] - $stats['pretransfer_time_us']) / 1000,
+					'transfer' => ($stats['total_time_us'] - $stats['starttransfer_time_us']) / 1000
+				] : null,
+				'size' => (object) [
+					'upload' => isset($stats['size_upload']) ? $stats['size_upload'] : null,
+					'download' => isset($stats['size_download']) ? $stats['size_download'] : null
+				],
+				'speed' => (object) [
+					'upload' => isset($stats['speed_upload']) ? $stats['speed_upload'] : null,
+					'download' => isset($stats['speed_download']) ? $stats['speed_download'] : null
+				],
+				'hosts' => (object) [
+					'local' => isset($stats['local_ip']) ? [ 'ip' => $stats['local_ip'], 'port' => $stats['local_port'] ] : null,
+					'remote' => isset($stats['primary_ip']) ? [ 'ip' => $stats['primary_ip'], 'port' => $stats['primary_port'] ] : null
+				],
+				'version' => isset($stats['http_version']) ? $stats['http_version'] : null 
+			] : null,
+			'error'    => null, 
+			'time'     => $startTime,
+			'duration' => (microtime(true) - $startTime) * 1000,
+			'trace'    => (new Serializer)->trace($trace)
+		];
+		
+		if ($this->passesFilters([ $request ])) {
+			$this->requests[] = $request;
+		}		
+	}
+	
+	// Resolve request content, with support for form data and json requests
+	protected function resolveRequestContent($request)
+	{
+		$body = (string) $request->getBody();
+		$headers = $request->getHeaders();
+		
+		if (isset($headers['Content-Type']) && $headers['Content-Type'][0] == 'application/x-www-form-urlencoded') {
+			parse_str($body, $parameters);
+			return $parameters;
+		} elseif (isset($headers['Content-Type']) && strpos($headers['Content-Type'][0], 'json') !== false) {
+			return json_decode($body, true);
+		}
+
+        return [];
+	}
+	
+	// Removes username and password from the URL
+	protected function removeAuthFromUrl($url)
+	{
+		return preg_replace('#^(.+?://)(.+?@)(.*)$#', '$1$3', $url);
+	}
+}

--- a/Clockwork/DataSource/GuzzleDataSource.php
+++ b/Clockwork/DataSource/GuzzleDataSource.php
@@ -19,6 +19,17 @@ class GuzzleDataSource extends DataSource
 	// Sent HTTP requests
 	protected $requests = [];
 	
+	// Whether to collect request and response content (json or form data) and raw content
+	protected $collectContent = true;
+	protected $collectRawContent = true;
+
+	// Create a new data source instance
+	public function __construct($collectContent = true, $collectRawContent = false)
+	{
+		$this->collectContent = $collectContent;
+		$this->collectRawContent = $collectRawContent;
+	}
+
 	// Returns a new Guzzle instance, pre-configured with Clockwork support
 	public function instance(array $config = [])
 	{
@@ -89,14 +100,14 @@ class GuzzleDataSource extends DataSource
 				'method'  => $request->getMethod(),
 				'url'     => $this->removeAuthFromUrl((string) $request->getUri()),
 				'headers' => $request->getHeaders(),
-				'content' => $this->resolveRequestContent($request),
-				'body'    => (string) $request->getBody(),
+				'content' => $this->collectContent ? $this->resolveRequestContent($request) : null,
+				'body'    => $this->collectRawContent ? (string) $request->getBody() : null
 			],
 			'response' => (object) [
 				'status'  => (int) $response->getStatusCode(),
 				'headers' => $response->getHeaders(),
-				'content' => json_decode((string) $response->getBody(), true),
-				'body'    => (string) $response->getBody()
+				'content' => $this->collectContent ? json_decode((string) $response->getBody(), true) : null,
+				'body'    => $this->collectRawContent ? (string) $response->getBody() : null
 			],
 			'stats'    => $stats ? (object) [
 				'timing' => isset($stats['total_time_us']) ? (object) [

--- a/Clockwork/DataSource/LaravelHttpClientDataSource.php
+++ b/Clockwork/DataSource/LaravelHttpClientDataSource.php
@@ -1,0 +1,134 @@
+<?php namespace Clockwork\DataSource;
+
+use Clockwork\Helpers\Serializer;
+use Clockwork\Helpers\StackTrace;
+use Clockwork\Request\Request;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Http\Client\Events\ConnectionFailed;
+use Illuminate\Http\Client\Events\RequestSending;
+use Illuminate\Http\Client\Events\ResponseReceived;
+
+// Data source for Laravel HTTP client, provides executed HTTP requests
+class LaravelHttpClientDataSource extends DataSource
+{
+	// Event dispatcher instance
+	protected $dispatcher;
+
+	// Sent notifications
+	protected $requests = [];
+	
+	// Map of executing requests, keyed by their object hash
+	protected $executingRequests = [];
+	
+	// Create a new data source instance, takes an event dispatcher as argument
+	public function __construct(Dispatcher $dispatcher)
+	{
+		$this->dispatcher = $dispatcher;
+	}
+	
+	// Add sent notifications to the request
+	public function resolve(Request $request)
+	{
+		$request->httpRequests = array_merge($request->httpRequests, $this->requests);
+		
+		$request->log()->debug($this->requests);
+	
+		return $request;
+	}
+	
+	// Reset the data source to an empty state, clearing any collected data
+	public function reset()
+	{
+		$this->requests = [];
+		$this->executingRequests = [];
+	}
+	
+	// Listen to the email and notification events
+	public function listenToEvents()
+	{
+		$this->dispatcher->listen(ConnectionFailed::class, function ($event) { $this->connectionFailed($event); });
+		$this->dispatcher->listen(RequestSending::class, function ($event) { $this->sendingRequest($event); });
+		$this->dispatcher->listen(ResponseReceived::class, function ($event) { $this->responseReceived($event); });
+	}
+	
+	// Collect an executing request
+	protected function sendingRequest(RequestSending $event)
+	{
+		$trace = StackTrace::get()->resolveViewName();
+		
+		$request = (object) [
+			'request'  => (object) [
+				'method'  => $event->request->method(),
+				'url'     => $event->request->url(),
+				'headers' => $event->request->headers(),
+				'content' => $event->request->data(),
+				'body'    => $event->request->body(),
+			],
+			'response' => null,
+			'stats'    => null,
+			'error'    => null, 
+			'time'     => microtime(true),
+			'trace'    => (new Serializer)->trace($trace)
+		];
+		
+		if ($this->passesFilters([ $request ])) {
+			$this->requests[] = $this->executingRequests[spl_object_hash($event->request)] = $request;
+		}
+	}
+
+	// Update last request with response details and time taken
+	protected function responseReceived($event)
+	{
+		if (! isset($this->executingRequests[spl_object_hash($event->request)])) return;
+		
+		$request = $this->executingRequests[spl_object_hash($event->request)];
+		$stats = $event->response->handlerStats();
+				
+		$request->duration = (microtime(true) - $request->time) * 1000;
+		$request->response = (object) [
+			'status'  => $event->response->status(),
+			'headers' => $event->response->headers(),
+			'content' => $event->response->json(),
+			'body'    => $event->response->body(),
+			'stats'   => $event->response->handlerStats()
+		];
+		$request->stats = (object) [
+			'timing' => isset($stats['total_time_us']) ? (object) [
+				'lookup' => $stats['namelookup_time_us'] / 1000,
+				'connect' => ($stats['pretransfer_time_us'] - $stats['namelookup_time_us']) / 1000,
+				'waiting' => ($stats['starttransfer_time_us'] - $stats['pretransfer_time_us']) / 1000,
+				'transfer' => ($stats['total_time_us'] - $stats['starttransfer_time_us']) / 1000
+			] : null,
+			'size' => (object) [
+				'upload' => isset($stats['size_upload']) ? $stats['size_upload'] : null,
+				'download' => isset($stats['size_download']) ? $stats['size_download'] : null
+			],
+			'speed' => (object) [
+				'upload' => isset($stats['speed_upload']) ? $stats['speed_upload'] : null,
+				'download' => isset($stats['speed_download']) ? $stats['speed_download'] : null
+			],
+			'hosts' => (object) [
+				'local' => isset($stats['local_ip']) ? [ 'ip' => $stats['local_ip'], 'port' => $stats['local_port'] ] : null,
+				'remote' => isset($stats['primary_ip']) ? [ 'ip' => $stats['primary_ip'], 'port' => $stats['primary_port'] ] : null
+			],
+			'version' => isset($stats['http_version']) ? $stats['http_version'] : null 
+		];
+		
+		unset($this->executingRequests[spl_object_hash($event->request)]);
+	}
+	
+	// Update last request with error when connection fails
+	protected function connectionFailed($event)
+	{
+		dd($event);
+		if (! isset($this->executingRequests[spl_object_hash($event->request)])) return;
+
+		$request = $this->executingRequests[spl_object_hash($event->request)];
+		
+		$request->duration = (microtime(true) - $request->time) * 1000;
+		$request->error = 'connection-failed';
+
+		unset($this->executingRequests[spl_object_hash($event->request)]);
+	}
+}

--- a/Clockwork/Request/Request.php
+++ b/Clockwork/Request/Request.php
@@ -133,6 +133,9 @@ class Request
 	// Custom user data
 	public $userData = [];
 
+	// HTTP requests
+	public $httpRequests = [];
+
 	// Subrequests
 	public $subrequests = [];
 
@@ -298,6 +301,7 @@ class Request
 			'userData'                 => array_map(function ($data) {
 				return $data instanceof UserData ? $data->toArray() : $data;
 			}, $this->userData),
+			'httpRequests'             => $this->httpRequests,
 			'subrequests'              => $this->subrequests,
 			'xdebug'                   => $this->xdebug,
 			'commandName'              => $this->commandName,

--- a/Clockwork/Support/Laravel/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Laravel/ClockworkServiceProvider.php
@@ -6,6 +6,7 @@ use Clockwork\DataSource\EloquentDataSource;
 use Clockwork\DataSource\LaravelCacheDataSource;
 use Clockwork\DataSource\LaravelDataSource;
 use Clockwork\DataSource\LaravelEventsDataSource;
+use Clockwork\DataSource\LaravelHttpClientDataSource;
 use Clockwork\DataSource\LaravelNotificationsDataSource;
 use Clockwork\DataSource\LaravelQueueDataSource;
 use Clockwork\DataSource\LaravelRedisDataSource;
@@ -151,6 +152,10 @@ class ClockworkServiceProvider extends ServiceProvider
 				$app['events'],
 				$app['clockwork.support']->getConfig('features.events.ignored_events', [])
 			));
+		});
+
+		$this->app->singleton('clockwork.http-requests', function ($app) {
+			return new LaravelHttpClientDataSource($app['events']);
 		});
 
 		$this->app->singleton('clockwork.laravel', function ($app) {

--- a/Clockwork/Support/Laravel/ClockworkServiceProvider.php
+++ b/Clockwork/Support/Laravel/ClockworkServiceProvider.php
@@ -155,7 +155,11 @@ class ClockworkServiceProvider extends ServiceProvider
 		});
 
 		$this->app->singleton('clockwork.http-requests', function ($app) {
-			return new LaravelHttpClientDataSource($app['events']);
+			return new LaravelHttpClientDataSource(
+				$app['events'],
+				$app['clockwork.support']->getConfig('features.http_requests.collect_data'),
+				$app['clockwork.support']->getConfig('features.http_requests.collect_raw_data')
+			);
 		});
 
 		$this->app->singleton('clockwork.laravel', function ($app) {

--- a/Clockwork/Support/Laravel/ClockworkSupport.php
+++ b/Clockwork/Support/Laravel/ClockworkSupport.php
@@ -160,6 +160,7 @@ class ClockworkSupport
 					? $this->app['clockwork.notifications'] : $this->app['clockwork.swift']
 			);
 		}
+		if ($this->isFeatureEnabled('http_requests')) $clockwork->addDataSource($this->app['clockwork.http-requests']);
 		if ($this->isFeatureAvailable('xdebug')) $clockwork->addDataSource($this->app['clockwork.xdebug']);
 		if ($this->isFeatureEnabled('views')) {
 			$clockwork->addDataSource(
@@ -179,6 +180,7 @@ class ClockworkSupport
 		if ($this->isFeatureEnabled('cache')) $this->app['clockwork.cache']->listenToEvents();
 		if ($this->isFeatureEnabled('database')) $this->app['clockwork.eloquent']->listenToEvents();
 		if ($this->isFeatureEnabled('events')) $this->app['clockwork.events']->listenToEvents();
+		if ($this->isFeatureEnabled('http_requests')) $this->app['clockwork.http-requests']->listenToEvents();
 		if ($this->isFeatureEnabled('notifications')) {
 			$this->isFeatureAvailable('notifications-events')
 				? $this->app['clockwork.notifications']->listenToEvents() : $this->app['clockwork.swift']->listenToEvents();
@@ -587,6 +589,8 @@ class ClockworkSupport
 	{
 		if ($feature == 'database') {
 			return $this->app['config']->get('database.default');
+		} elseif ($feature == 'http_requests') {
+			return class_exists(\Illuminate\Http\Client\Request::class);
 		} elseif ($feature == 'notifications-events') {
 			return class_exists(\Illuminate\Mail\Events\MessageSent::class)
 				&& class_exists(\Illuminate\Notifications\Events\NotificationSent::class);

--- a/Clockwork/Support/Laravel/config/clockwork.php
+++ b/Clockwork/Support/Laravel/config/clockwork.php
@@ -72,6 +72,11 @@ return [
 			],
 		],
 
+		// Sent HTTP requests
+		'http_requests' => [
+			'enabled' => env('CLOCKWORK_HTTP_REQUESTS_ENABLED', true),
+		],
+
 		// Laravel log (you can still log directly to Clockwork with laravel log disabled)
 		'log' => [
 			'enabled' => env('CLOCKWORK_LOG_ENABLED', true)

--- a/Clockwork/Support/Laravel/config/clockwork.php
+++ b/Clockwork/Support/Laravel/config/clockwork.php
@@ -75,6 +75,12 @@ return [
 		// Sent HTTP requests
 		'http_requests' => [
 			'enabled' => env('CLOCKWORK_HTTP_REQUESTS_ENABLED', true),
+
+			// Collect structured request and response content (json and form data)
+			'collect_data' => env('CLOCKWORK_HTTP_REQUESTS_COLLECT_DATA', true),
+
+			// Collect raw request and response content (high storage usage with large responses)
+			'collect_raw_data' => env('CLOCKWORK_HTTP_REQUESTS_COLLECT_RAW_DATA', false)
 		],
 
 		// Laravel log (you can still log directly to Clockwork with laravel log disabled)


### PR DESCRIPTION
- Added support for collecting Laravel HTTP client requests.
- Collects basic information like method, url, status, request & response data, optionally raw request and response bodies, computes response time, advanced stats and timings, etc.
- Supports Laravel 7+, based on the Laravel event system.
- Also supports manual usage with Guzzle 7.
- Clockwork app [PR](https://github.com/underground-works/clockwork-app/pull/117) w/ screenshots.

Example usage of the Guzzle integration:
```php
// Instantiate the Guzzle data source
$guzzleDataSource = new \Clockwork\DataSource\GuzzleDataSource;

// Option 1 - Get a new Guzzle instance w/ Clockwork support
$guzzle = $guzzleDataSource->instance([ 'verify' => false ]);

// Option 2 - Extend a Guzzle configuration array w/ Clockwork support
$guzzle = new \GuzzleHttp\Client($guzzleDataSource->configure([ 'verify' => false ]));

// Option 3 - Manually instantiate a Guzzle instance w/ Clockwork support
$handler = \GuzzleHttp\HandlerStack::create();		
$handler->push($guzzleDataSource);
$guzzle = new \GuzzleHttp\Client([ 'handler' => $handler, 'verify' => false ]);

// Add the data source to your Clockwork instance
$clockwork->addDataSource($guzzleDataSource);
```
