### PR TITLE
Enhance Handling of __PHP_Incomplete_Class Instances in normalize Method

### DIFF
--- a/Clockwork/Helpers/Serializer.php
+++ b/Clockwork/Helpers/Serializer.php
@@ -56,6 +56,8 @@ class Serializer
 			$className = get_class($data);
 			$objectHash = spl_object_hash($data);
 
+			if ($className === '__PHP_Incomplete_Class') return [ '__class__' => $className ];
+
 			if ($limit === 0) return [ '__class__' => $className, '__omitted__' => 'limit' ];
 
 			if (isset($context['references'][$objectHash])) return [ '__type__' => 'recursion' ];


### PR DESCRIPTION
## Summary
This PR introduces an improvement to the `normalize` method's handling of `__PHP_Incomplete_Class` instances. By checking for this class name early in the object handling logic, we prevent further processing on incomplete objects introduced here #695 

## Changes
- Added an early return condition in the `normalize` method for objects of type `__PHP_Incomplete_Class`, returning a simplified array with the class name.

## Rationale
Encountering incomplete class instances during normalization can lead to errors or undefined behavior since such objects lack a fully defined class definition.

## Impact
This update improves the robustness of the normalization process with minimal impact on the existing functionality.