### PR TITLE
Doctrine 3+ support

### DIFF
--- a/Clockwork/DataSource/DBALDataSource.php
+++ b/Clockwork/DataSource/DBALDataSource.php
@@ -1,45 +1,56 @@
 <?php namespace Clockwork\DataSource;
 
 use Clockwork\Request\Request;
+use Clockwork\Support\Doctrine\Middleware;
+use Clockwork\Support\Doctrine\Legacy\Logger;
 
-use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Logging\{LoggerChain, SQLLogger};
-use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\{Configuration, Connection};
 
 // Data source for DBAL, provides database queries
-class DBALDataSource extends DataSource implements SQLLogger
+class DBALDataSource extends DataSource
 {
 	// Array of collected queries
 	protected $queries = [];
 
-	// Current running query
-	protected $query = null;
-
-	// DBAL connection
-	protected $connection;
-
 	// DBAL connection name
 	protected $connectionName;
 
-	// Create a new data source instance, takes a DBAL connection instance as an argument
-	public function __construct(Connection $connection)
+	protected $logger;
+
+	// Create a new data source instance, takes a DBAL connection instance as an argument (for Doctrine 2.x)
+	public function __construct(?Connection $connection = null)
 	{
-		$this->connection = $connection;
-		$this->connectionName = $this->connection->getDatabase();
+		$this->connectionName = $connection ? $connection->getDatabase() : null;
 
-		$configuration = $this->connection->getConfiguration();
-		$currentLogger = $configuration->getSQLLogger();
-
-		if ($currentLogger === null) {
-			$configuration->setSQLLogger($this);
-		} else {
-			$loggerChain = new LoggerChain;
-			$loggerChain->addLogger($currentLogger);
-			$loggerChain->addLogger($this);
-
-			$configuration->setSQLLogger($loggerChain);
+		if (! class_exists(\Doctrine\DBAL\Logging\Middleware::class)) {
+			$this->setupLegacyDoctrine($connection);
 		}
+	}
+
+	// Update Doctrine configuration to include the Clockwork logging middleware (for Doctrine 3+)
+	public function configure(?Configuration $configuration = null)
+	{
+		$configuration = $configuration ?? new Configuration;
+
+		return $configuration->setMiddlewares(array_merge(
+			$configuration->getMiddlewares(), [ $this->middleware() ]
+		));
+	}
+
+	// Returns an instance of Clockwork logging middleware associated with this data source (for Doctrine 3+)
+	public function middleware()
+	{
+		return $this->logger = new Middleware(function ($query) {
+			$this->registerQuery($query);
+		});
+	}
+
+	// Setup Clockwork logger for legacy Doctrine 2.x
+	protected function setupLegacyDoctrine(Connection $connection)
+	{
+		$this->logger = new Logger($connection, function ($query) {
+			$this->registerQuery($query);
+		});
 	}
 
 	// Adds executed database queries to the request
@@ -57,134 +68,14 @@ class DBALDataSource extends DataSource implements SQLLogger
 		$this->query = null;
 	}
 
-	// DBAL SQLLogger event
-	public function startQuery($sql, ?array $params = null, ?array $types = null)
-	{
-		$this->query = [
-			'query'  => $sql,
-			'params' => $params,
-			'types'  => $types,
-			'time'   => microtime(true)
-		];
-	}
-
-	// DBAL SQLLogger event
-	public function stopQuery()
-	{
-		$this->registerQuery($this->query);
-		$this->query = null;
-	}
-
 	// Collect an executed database query
 	protected function registerQuery($query)
 	{
-		$query = [
-			'query'      => $this->createRunnableQuery($query['query'], $query['params'], $query['types']),
-			'bindings'   => $query['params'],
-			'duration'   => (microtime(true) - $query['time']) * 1000,
-			'connection' => $this->connectionName,
-			'time'       => $query['time']
-		];
+		$query['duration'] = (microtime(true) - $query['time']) * 1000;
+		$query['connection'] = $query['connection'] ?? $this->connectionName;
 
 		if ($this->passesFilters([ $query ])) {
 			$this->queries[] = $query;
 		}
-	}
-
-	// Takes a query, an array of params and types as arguments, returns runnable query with upper-cased keywords
-	protected function createRunnableQuery($query, $params, $types)
-	{
-		// add params to query
-		$query = $this->replaceParams($this->connection->getDatabasePlatform(), $query, $params, $types);
-
-		// highlight keywords
-		$keywords = [
-			'select', 'insert', 'update', 'delete', 'into', 'values', 'set', 'where', 'from', 'limit', 'is', 'null',
-			'having', 'group by', 'order by', 'asc', 'desc'
-		];
-		$regexp = '/\b' . implode('\b|\b', $keywords) . '\b/i';
-
-		return preg_replace_callback($regexp, function ($match) { return strtoupper($match[0]); }, $query);
-	}
-
-	/**
-	 * Source at laravel-doctrine/orm LaravelDoctrine\ORM\Loggers\Formatters\ReplaceQueryParams::format().
-	 *
-	 * @param AbstractPlatform $platform
-	 * @param string           $sql
-	 * @param array|null       $params
-	 * @param array|null       $types
-	 *
-	 *
-	 * @return string
-	 */
-	public function replaceParams($platform, $sql, ?array $params = null, ?array $types = null)
-	{
-		if (is_array($params)) {
-			foreach ($params as $key => $param) {
-				$type  = $types[$key] ?? null;
-				$param = $this->convertParam($platform, $param, $type);
-				$sql   = preg_replace('/\?/', "$param", $sql, 1);
-			}
-		}
-		return $sql;
-	}
-
-	/**
-	 * Source at laravel-doctrine/orm LaravelDoctrine\ORM\Loggers\Formatters\ReplaceQueryParams::convertParam().
-	 *
-	 * @param mixed $param
-	 *
-	 * @throws \Exception
-	 * @return string
-	 */
-	protected function convertParam($platform, $param, $type = null)
-	{
-		if (is_object($param)) {
-			if (!method_exists($param, '__toString')) {
-				if ($param instanceof \DateTimeInterface) {
-					$param = $param->format('Y-m-d H:i:s');
-				} elseif (Type::hasType($type)) {
-					$type  = Type::getType($type);
-					$param = $type->convertToDatabaseValue($param, $platform);
-				} else {
-					throw new \Exception('Given query param is an instance of ' . get_class($param) . ' and could not be converted to a string');
-				}
-			}
-		} elseif (is_array($param)) {
-			if ($this->isNestedArray($param)) {
-				$param = json_encode($param, JSON_UNESCAPED_UNICODE);
-			} else {
-				$param = implode(
-					', ',
-					array_map(
-						function ($part) {
-							return '"' . (string) $part . '"';
-						},
-						$param
-					)
-				);
-				return '(' . $param . ')';
-			}
-		} else {
-			$param = htmlspecialchars((string) $param); // Originally used the e() Laravel helper
-		}
-		return '"' . (string) $param . '"';
-	}
-
-	/**
-	 * Source at laravel-doctrine/orm LaravelDoctrine\ORM\Loggers\Formatters\ReplaceQueryParams::isNestedArray().
-	 *
-	 * @param  array $array
-	 * @return bool
-	 */
-	private function isNestedArray(array $array)
-	{
-		foreach ($array as $key => $value) {
-			if (is_array($value)) {
-				return true;
-			}
-		}
-		return false;
 	}
 }

--- a/Clockwork/DataSource/DoctrineDataSource.php
+++ b/Clockwork/DataSource/DoctrineDataSource.php
@@ -5,8 +5,8 @@ use Doctrine\ORM\EntityManager;
 // Data source for Doctrine, provides database queries
 class DoctrineDataSource extends DBALDataSource
 {
-	public function __construct(EntityManager $enm)
+	public function __construct(?EntityManager $enm = null)
 	{
-		parent::__construct($enm->getConnection());
+		parent::__construct($enm ? $enm->getConnection() : null);
 	}
 }

--- a/Clockwork/Support/Doctrine/Connection.php
+++ b/Clockwork/Support/Doctrine/Connection.php
@@ -1,0 +1,40 @@
+<?php namespace Clockwork\Support\Doctrine;
+
+use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
+use Doctrine\DBAL\Driver\Middleware\AbstractConnectionMiddleware;
+use Doctrine\DBAL\Driver\Result;
+
+// Part of the Clockwork logging middleware, should not be used directly
+class Connection extends AbstractConnectionMiddleware
+{
+	protected $onQuery;
+
+	public function __construct(ConnectionInterface $connection, $onQuery)
+	{
+		parent::__construct($connection);
+
+		$this->onQuery = $onQuery;
+	}
+
+	public function query(string $sql): Result
+	{
+		$time = microtime(true);
+
+		$result = parent::query($sql);
+
+		($this->onQuery)([ 'query' => $sql, 'time' => $time ]);
+
+		return $result;
+	}
+
+	public function exec(string $sql): int
+	{
+		$time = microtime(true);
+
+		$result = parent::exec($sql);
+
+		($this->onQuery)([ 'query' => $sql, 'time' => $time ]);
+
+		return $result;
+	}
+}

--- a/Clockwork/Support/Doctrine/Driver.php
+++ b/Clockwork/Support/Doctrine/Driver.php
@@ -1,0 +1,22 @@
+<?php namespace Clockwork\Support\Doctrine;
+
+use Doctrine\DBAL\Driver as DriverInterface;
+use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
+
+// Part of the Clockwork logging middleware, should not be used directly
+class Driver extends AbstractDriverMiddleware
+{
+	protected $onQuery;
+
+	public function __construct(DriverInterface $driver, $onQuery)
+	{
+		parent::__construct($driver);
+
+		$this->onQuery = $onQuery;
+	}
+
+	public function connect(array $params): Connection
+	{
+		return new Connection(parent::connect($params), $this->onQuery);
+	}
+}

--- a/Clockwork/Support/Doctrine/Legacy/Logger.php
+++ b/Clockwork/Support/Doctrine/Legacy/Logger.php
@@ -1,0 +1,165 @@
+<?php namespace Clockwork\Support\Doctrine\Legacy;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Logging\{LoggerChain, SQLLogger};
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+
+// Clockwork logger for legacy Doctrine 2.x
+class Logger implements SQLLogger
+{
+	// On-query callback
+	protected $onQuery;
+
+	// Current running query
+	protected $query = null;
+
+	// DBAL connection
+	protected $connection;
+
+	// Create a new logger instance, takes a DBAL connection instance and on-query callback as arguments
+	public function __construct(Connection $connection, Callable $onQuery)
+	{
+		$this->onQuery = $onQuery;
+
+		$this->connection = $connection;
+
+		$configuration = $this->connection->getConfiguration();
+		$currentLogger = $configuration->getSQLLogger();
+
+		if ($currentLogger === null) {
+			$configuration->setSQLLogger($this);
+		} else {
+			$loggerChain = new LoggerChain;
+			$loggerChain->addLogger($currentLogger);
+			$loggerChain->addLogger($this);
+
+			$configuration->setSQLLogger($loggerChain);
+		}
+	}
+
+	// DBAL SQLLogger event
+	public function startQuery($sql, ?array $params = null, ?array $types = null)
+	{
+		$this->query = [
+			'query'  => $sql,
+			'params' => $params,
+			'types'  => $types,
+			'time'   => microtime(true)
+		];
+	}
+
+	// DBAL SQLLogger event
+	public function stopQuery()
+	{
+		$this->registerQuery($this->query);
+		$this->query = null;
+	}
+
+	// Collect an executed database query
+	protected function registerQuery($query)
+	{
+		($this->onQuery)([
+			'query'    => $this->createRunnableQuery($query['query'], $query['params'], $query['types']),
+			'bindings' => $query['params'],
+			'time'     => $query['time']
+		]);
+	}
+
+	// Takes a query, an array of params and types as arguments, returns runnable query with upper-cased keywords
+	protected function createRunnableQuery($query, $params, $types)
+	{
+		// add params to query
+		$query = $this->replaceParams($this->connection->getDatabasePlatform(), $query, $params, $types);
+
+		// highlight keywords
+		$keywords = [
+			'select', 'insert', 'update', 'delete', 'into', 'values', 'set', 'where', 'from', 'limit', 'is', 'null',
+			'having', 'group by', 'order by', 'asc', 'desc'
+		];
+		$regexp = '/\b' . implode('\b|\b', $keywords) . '\b/i';
+
+		return preg_replace_callback($regexp, function ($match) { return strtoupper($match[0]); }, $query);
+	}
+
+	/**
+	 * Source at laravel-doctrine/orm LaravelDoctrine\ORM\Loggers\Formatters\ReplaceQueryParams::format().
+	 *
+	 * @param AbstractPlatform $platform
+	 * @param string           $sql
+	 * @param array|null       $params
+	 * @param array|null       $types
+	 *
+	 *
+	 * @return string
+	 */
+	public function replaceParams($platform, $sql, ?array $params = null, ?array $types = null)
+	{
+		if (is_array($params)) {
+			foreach ($params as $key => $param) {
+				$type  = $types[$key] ?? null;
+				$param = $this->convertParam($platform, $param, $type);
+				$sql   = preg_replace('/\?/', "$param", $sql, 1);
+			}
+		}
+		return $sql;
+	}
+
+	/**
+	 * Source at laravel-doctrine/orm LaravelDoctrine\ORM\Loggers\Formatters\ReplaceQueryParams::convertParam().
+	 *
+	 * @param mixed $param
+	 *
+	 * @throws \Exception
+	 * @return string
+	 */
+	protected function convertParam($platform, $param, $type = null)
+	{
+		if (is_object($param)) {
+			if (!method_exists($param, '__toString')) {
+				if ($param instanceof \DateTimeInterface) {
+					$param = $param->format('Y-m-d H:i:s');
+				} elseif (Type::hasType($type)) {
+					$type  = Type::getType($type);
+					$param = $type->convertToDatabaseValue($param, $platform);
+				} else {
+					throw new \Exception('Given query param is an instance of ' . get_class($param) . ' and could not be converted to a string');
+				}
+			}
+		} elseif (is_array($param)) {
+			if ($this->isNestedArray($param)) {
+				$param = json_encode($param, JSON_UNESCAPED_UNICODE);
+			} else {
+				$param = implode(
+					', ',
+					array_map(
+						function ($part) {
+							return '"' . (string) $part . '"';
+						},
+						$param
+					)
+				);
+				return '(' . $param . ')';
+			}
+		} else {
+			$param = htmlspecialchars((string) $param); // Originally used the e() Laravel helper
+		}
+		return '"' . (string) $param . '"';
+	}
+
+	/**
+	 * Source at laravel-doctrine/orm LaravelDoctrine\ORM\Loggers\Formatters\ReplaceQueryParams::isNestedArray().
+	 *
+	 * @param  array $array
+	 * @return bool
+	 */
+	private function isNestedArray(array $array)
+	{
+		foreach ($array as $key => $value) {
+			if (is_array($value)) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/Clockwork/Support/Doctrine/Middleware.php
+++ b/Clockwork/Support/Doctrine/Middleware.php
@@ -1,0 +1,22 @@
+<?php namespace Clockwork\Support\Doctrine;
+
+use Doctrine\DBAL\Driver as DriverInterface;
+use Doctrine\DBAL\Driver\Middleware as MiddlewareInterface;
+
+// Clockwork logging middleware for Doctrine 3+
+class Middleware implements MiddlewareInterface
+{
+	// On-query callback
+	protected $onQuery;
+
+	// Create a new middleware instance, takes an on-query callback as argument
+	public function __construct($onQuery)
+	{
+		$this->onQuery = $onQuery;
+	}
+
+	public function wrap(DriverInterface $driver): DriverInterface
+	{
+		return new Driver($driver, $this->onQuery);
+	}
+}


### PR DESCRIPTION
- This PR adds support for Doctrine versions 3 and up.
- Doctrine 3 support is implemented via a middleware and requires manual configuration as Doctrine does not allow adding middleware on runtime (examples below).
- Doctrine 2 is still supported with no breaking changes (the SQLLogger implementation has been extracted into a separate class, it's unlikely this affects anyone).

Using the `configure` helper to register the middleware:

```php
$clockwork->addDataSource($dataSource = new \Clockwork\DataSource\DoctrineDataSource);

$config = ORMSetup::createAttributeMetadataConfiguration(paths: [__DIR__], isDevMode: true);
$config = $dataSource->configure($config);
```

Manually adding the middleware:

```php
$clockwork->addDataSource($dataSource = new \Clockwork\DataSource\DoctrineDataSource);

$config = ORMSetup::createAttributeMetadataConfiguration(paths: [__DIR__], isDevMode: true)
    ->setMiddlewares([ $dataSource->middleware() ]);
```