### PR TITLE
fix implicitly nullable via default value null for PHP-8.4

### DIFF
--- a/Clockwork/Support/Vanilla/Clockwork.php
+++ b/Clockwork/Support/Vanilla/Clockwork.php
@@ -336,7 +336,7 @@ class Clockwork
 	}
 
 	// Use a PSR-7 request and response instances instead of vanilla php HTTP apis
-	public function usePsrMessage(PsrRequest $request, PsrResponse $response = null)
+	public function usePsrMessage(PsrRequest $request, ?PsrResponse $response = null)
 	{
 		$this->psrRequest = $request;
 		$this->psrResponse = $response;


### PR DESCRIPTION
use of explicit nullable type for php-8.4 compatibility