### PR TITLE
Fix Call to a member function getBody() on null

### DIFF
--- a/Clockwork/DataSource/GuzzleDataSource.php
+++ b/Clockwork/DataSource/GuzzleDataSource.php
@@ -130,7 +130,7 @@ class GuzzleDataSource extends DataSource
 			'trace'    => (new Serializer)->trace($trace)
 		];
 		
-		if ($response->getBody()->tell()) $response->getBody()->rewind();
+		if ($response && $response->getBody()->tell()) $response->getBody()->rewind();
 
 		if ($this->passesFilters([ $request ])) {
 			$this->requests[] = $request;


### PR DESCRIPTION
Response can be null (connection issues etc.), then this line throws exception: `Fix Call to a member function getBody() on null`

This PR adds an extra check that the response exists.