### PR TITLE
Timeline - Allow duplicates with same description

### DIFF
--- a/Clockwork/Request/Timeline/Timeline.php
+++ b/Clockwork/Request/Timeline/Timeline.php
@@ -34,7 +34,10 @@ class Timeline
 	public function find($name)
 	{
 		foreach ($this->events as $event) {
-			if ($event->name == $name) return $event;
+			if ($event->name == $name) {
+				// only return events if they are not done yet. Allows for having multiple events with the same description on the timeline
+				if($event->end === null) return $event;
+			}
 		}
 	}
 


### PR DESCRIPTION
If there's repeated queries or other events being logged, it would keep overwriting the start and end times. 

This fix allows to see all of the events.