### PR TITLE
EloquentDataSource - ignore placeholders inside SQL comments and strings

### DIFF
--- a/Clockwork/DataSource/EloquentDataSource.php
+++ b/Clockwork/DataSource/EloquentDataSource.php
@@ -268,25 +268,38 @@ class EloquentDataSource extends DataSource
 	{
 		// add bindings to query
 		$bindings = $this->databaseManager->connection($connection)->prepareBindings($bindings);
-
+		
+		$bindingsArePositional = array_keys($bindings) === range(0, count($bindings) - 1);
+		
+		/**
+		 * Regexp explanation:
+		 * ('(?:''|[^'])*')   - single quoted string (handles escaped single quotes by doubling)
+		 * ("(?:""|[^"])*")   - double quoted string (handles escaped double quotes by doubling)
+		 * (--.*)             - single-line comment
+		 * (\/\*[\s\S]*?\*\/) - multi-line comment
+		 * (*SKIP)(*FAIL)     - skip all matches above
+		 * \?                 - positional placeholder
+		 * :\w+               - named placeholder
+		 */
+		$pattern = $bindingsArePositional
+			? "/('(?:''|[^'])*'|\"(?:\"\"|[^\"])*\"|--.*|\/\*[\s\S]*?\*\/)(*SKIP)(*FAIL)|\?/"
+			: "/('(?:''|[^'])*'|\"(?:\"\"|[^\"])*\"|--.*|\/\*[\s\S]*?\*\/)(*SKIP)(*FAIL)|:\w+/";
+		
+		
 		$index = 0;
-		$query = preg_replace_callback('/\'[^\']*\'|[^?]\?|\W:[a-z]+/', function ($matches) use ($bindings, $connection, &$index) {
-			$match = $matches[0];
-
-			if ($match[0] == '\'') { // quoted string
-				return $match;
-			} elseif ($match[1] == '?' && isset($bindings[$index])) { // question-mark binding
-				$binding = $this->quoteBinding($bindings[$index++], $connection);
-			} elseif ($match[1] == ':' && isset($bindings[substr($match, 2)])) { // named binding
-				$binding = $this->quoteBinding($bindings[substr($match, 2)], $connection);
-			} else {
-				return $match;
-			}
-
+		$query = preg_replace_callback($pattern, function ($matches) use ($bindings, $connection, &$index, $bindingsArePositional) {
+			$binding = $bindingsArePositional
+				? $bindings[$index++]
+				: $bindings[ltrim($matches[$index++], ':')];
+			
+			$binding = $this->quoteBinding($binding, $connection);
+			
 			// convert binary bindings to hexadecimal representation
-			if (! preg_match('//u', (string) $binding)) $binding = '0x' . bin2hex($binding);
-
-			return $match[0] . ((string) $binding);
+			if (!preg_match('//u', (string)$binding)) {
+				$binding = '0x' . bin2hex($binding);
+			}
+			
+			return (string)$binding;
 		}, $query);
 
 		// highlight keywords


### PR DESCRIPTION
Hello! I noticed that if an Eloquent query contains comments, the `EloquentDataSource::createRunnableQuery` function handles bindings replacement incorrectly.

## Case 1

When using **named bindings** and having a question mark inside SQL comments, an exception occurs:
`Undefined array key 0` at `EloquentDataSource.php:274`,
because the function tries to replace the `?` with a positional binding, but there is no binding with key `0`.

**How to reproduce:**

```php
$bindings = [
    'id' => 1
];

$query = <<<SQL
    SELECT
        *
    FROM
        users -- is that correct table?
    WHERE
        id = :id
SQL;

DB::select($query, $bindings);
```

## Case 2

When using **positional bindings** and having a question mark inside SQL comments, the function incorrectly replaces question marks in the comment with bindings, instead of replacing only the real `?` in the query.

**How to reproduce:**

```php
$bindings = [
    1
];

$query = <<<SQL
    SELECT
        *
    FROM
        users -- is that correct table?
    WHERE
        id = ?
SQL;

DB::select($query, $bindings);
```

**Result:**

```
SELECT
    *
FROM
    users -- IS that correct table1
WHERE
    id = ?
```

## Fix

I propose to determine whether the bindings are positional before performing the replacements.

Eloquent allows queries to use either positional or named parameters.
I check whether the bindings are positional by verifying that the bindings array contains only numerically ordered keys.

The updated regular expression now ignores placeholders inside:

* Single-line comments (`-- ...`)
* Multi-line comments (`/* ... */`)
* Single-quoted string literals (`'...'`)
* Double-quoted string literals (`"..."`)

This ensures that placeholders are replaced only where intended, preventing accidental replacements inside comments or strings.