### PR TITLE
Reset duplicateQueries on EloquentDataSource

### DIFF
--- a/Clockwork/DataSource/EloquentDataSource.php
+++ b/Clockwork/DataSource/EloquentDataSource.php
@@ -107,6 +107,8 @@ class EloquentDataSource extends DataSource
 		];
 
 		$this->nextQueryModel = null;
+
+		if ($this->detectDuplicateQueries) $this->duplicateQueries = [];
 	}
 
 	// Start listening to Eloquent events


### PR DESCRIPTION
When using Laravel Octane, the package does reset all registered data sources every time new request received by listening to Octane RequestReceived event. However, one field is missed to be reset in EloquentDataSource with detect duplicate query enabled: `$duplicateQueries` located in [EloquentDetectDuplicateQueries](https://github.com/itsgoingd/clockwork/blob/master/Clockwork/DataSource/Concerns/EloquentDetectDuplicateQueries.php) trait.

The workaround for this issue is by manually reset the field by using reflection on the `clockwork.eloquent` singleton, inside listener to the same Octane event. I hope this PR can be merged soon so I can dispose the workaround code during development.

Thank you.