### PR TITLE
Fix quoted bindings for non-PDO connections

### DIFF
--- a/Clockwork/DataSource/EloquentDataSource.php
+++ b/Clockwork/DataSource/EloquentDataSource.php
@@ -310,8 +310,9 @@ class EloquentDataSource extends DataSource
 
 		$pdo = $connection->getPdo();
 
+		// In case of non-PDO connections or known drivers without quote support (ODBC, Crate), we apply our own simple MSSQL style quoting instead.
+		// Some drivers use object bindings (eg. Crate), in this case we try to JSON encode the value.
 		if ($pdo === null || $pdo->getAttribute(\PDO::ATTR_DRIVER_NAME) === 'odbc' || $pdo->getAttribute(\PDO::ATTR_DRIVER_NAME) === 'crate') {
-			// PDO_ODBC and PDO Crate driver doesn't support the quote method, apply simple MSSQL style quoting instead - Crate sometimes uses a object as a binding - for json support
 			$binding = is_object($binding) ? json_encode($binding) : $binding;
 			return "'" . str_replace("'", "''", $binding) . "'";
 		}

--- a/Clockwork/DataSource/EloquentDataSource.php
+++ b/Clockwork/DataSource/EloquentDataSource.php
@@ -310,9 +310,7 @@ class EloquentDataSource extends DataSource
 
 		$pdo = $connection->getPdo();
 
-		if ($pdo === null) return;
-
-		if ($pdo->getAttribute(\PDO::ATTR_DRIVER_NAME) === 'odbc' || $pdo->getAttribute(\PDO::ATTR_DRIVER_NAME) === 'crate') {
+		if ($pdo === null || $pdo->getAttribute(\PDO::ATTR_DRIVER_NAME) === 'odbc' || $pdo->getAttribute(\PDO::ATTR_DRIVER_NAME) === 'crate') {
 			// PDO_ODBC and PDO Crate driver doesn't support the quote method, apply simple MSSQL style quoting instead - Crate sometimes uses a object as a binding - for json support
 			$binding = is_object($binding) ? json_encode($binding) : $binding;
 			return "'" . str_replace("'", "''", $binding) . "'";


### PR DESCRIPTION
When using a non-PDO connection (e.g. https://github.com/glushkovds/phpclickhouse-laravel), parameter bindings were empty.

The fallback quoting mechanism in Clockwork uses `str_replace()` instead of `$pdo->quote()`, so we can also use it for non-PDO connections,

### Before:
<img width="2400" height="600" alt="Bildschirmfoto am 2026-02-08 um 01 14 26" src="https://github.com/user-attachments/assets/ba035bbd-47d5-4ec2-95f0-3a64c9c1c1ce" />

### After:
<img width="2400" height="600" alt="Bildschirmfoto am 2026-02-08 um 01 14 43" src="https://github.com/user-attachments/assets/f42d8e8c-d32f-41ca-81e3-d17c984993d2" />
